### PR TITLE
Fitspec fixes

### DIFF
--- a/swfiles/sw_readspec.m
+++ b/swfiles/sw_readspec.m
@@ -133,8 +133,9 @@ while ~feof(fid)
         
         % sort intensity, put zero intensities to the end
         [data{polIdx}.I,idx] = sort(data{polIdx}.I,1,'descend');
-        data{polIdx}.E       = data{polIdx}.E(sub2ind(size(data{polIdx}.E),idx,repmat(1:size(data{polIdx}.E,2),[2 1])));
-        data{polIdx}.sigma   = data{polIdx}.sigma(sub2ind(size(data{polIdx}.E),idx,repmat(1:size(data{polIdx}.E,2),[2 1])));
+        nModes = size(data{polIdx}.I, 1);
+        data{polIdx}.E       = data{polIdx}.E(sub2ind(size(data{polIdx}.E), idx, repmat(1:size(data{polIdx}.E,2), [nModes 1])));
+        data{polIdx}.sigma   = data{polIdx}.sigma(sub2ind(size(data{polIdx}.E), idx, repmat(1:size(data{polIdx}.E,2), [nModes 1])));
         
         data{polIdx}.nMode = sum(data{polIdx}.I~=0,1);
         data{polIdx}.corr  = sw_parstr(modeStr{polIdx});


### PR DESCRIPTION
Fixes two issues in `spinw.fitspec`:

1. Input files implicitly assumed to have two modes (which works for the LuVO3 example, tutorial 35).
2. By default the `imagChk` option is true, which causes fits to crash if any iteration yields large imaginary modes.

In the PR, `sw_readspec` is fixed to allow arbitrary number of modes in the input file, and the `imagChk` option to **`fitspec`** (not `spinwave`) is changed to `penalize` by default which still checks if there are large imaginary modes for a given iteration, but if there are, instead of crashing it will give a large penalty against this mode.