### PR TITLE
Vsave cell format in case of twins

### DIFF
--- a/swfiles/@spinw/spinwave.m
+++ b/swfiles/@spinw/spinwave.m
@@ -1022,7 +1022,11 @@ spectra.nformula = double(obj.unit.nformula);
 
 % Save different intermediate results.
 if param.saveV
-    spectra.V = Vsave;
+    if param.notwin
+        spectra.V = Vsave;
+    else
+        spectra.V = mat2cell(Vsave, size(Vsave, 1), size(Vsave, 1), repmat(nHkl0, [1 nTwin]));
+    end
 end
 if param.saveH
     spectra.H = Hsave;


### PR DESCRIPTION
SpinW handles twins by generating additional sets of Q points for each twin and appending these to the original Q point. After the memory management look it parses this and applies the necessary rotations to the calculation of `Sab`, putting the results (and also rearrangine `omega`) into a cell array with one cell per twin.

The eigenvector matrix however, is left as a `nMode` x `nMode` x `nTwin*nQ` 3D matrix rather than a cell array.

This PR changes it to an `nTwin` element cell array with each cell being a `nMode` x `nMode` x `nQ` matrix for to each twin.