### PR TITLE
Add tests for field

### DIFF
--- a/+sw_tests/+unit_tests/unittest_spinw_field.m
+++ b/+sw_tests/+unit_tests/unittest_spinw_field.m
@@ -1,59 +1,63 @@
 classdef unittest_spinw_field < sw_tests.unit_tests.unittest_super
+    properties
+        swobj
+    end
+    properties (TestParameter)
+        incorrect_input = {0, [1; 1], ones(1, 4)};
+    end
+    methods(TestMethodSetup)
+        function create_sw_model(testCase)
+            testCase.swobj = spinw();
+        end
+    end
     methods (Test)
-        function test_incorrect_shape_field_raises_error(testCase)
-            swobj = spinw();
+        function test_incorrect_shape_field_raises_error(testCase, ...
+                                                         incorrect_input)
             testCase.verifyError(...
-                @() field(swobj, [0; 0]), ...
+                @() field(testCase.swobj, incorrect_input), ...
                 'spinw:magfield:ArraySize');
         end
         function test_default_field(testCase)
-            swobj = spinw();
-            testCase.assertEqual(field(swobj), [0 0 0]);
+            testCase.assertEqual(field(testCase.swobj), [0 0 0]);
         end
         function test_set_field(testCase)
-            swobj = spinw();
             field_val = [1 2 3];
-            field(swobj, field_val);
-            testCase.assertEqual(field(swobj), field_val);
+            field(testCase.swobj, field_val);
+            testCase.assertEqual(field(testCase.swobj), field_val);
         end
         function test_set_field_column_vector(testCase)
-            swobj = spinw();
             field_val = [1; 2; 3];
-            field(swobj, field_val);
-            testCase.assertEqual(field(swobj), field_val');
+            field(testCase.swobj, field_val);
+            testCase.assertEqual(field(testCase.swobj), field_val');
         end
         function test_set_field_multiple_times(testCase)
-            swobj = spinw();
-            field(swobj, [1 2 3]);
+            field(testCase.swobj, [1 2 3]);
             new_field_val = [1.5 2.5 -3.5];
-            field(swobj, new_field_val);
-            testCase.assertEqual(field(swobj), new_field_val);
+            field(testCase.swobj, new_field_val);
+            testCase.assertEqual(field(testCase.swobj), new_field_val);
         end
         function test_returns_spinw_obj(testCase)
-            swobj = spinw();
             field_val = [1 2 3];
-            new_swobj = field(swobj, field_val);
+            new_swobj = field(testCase.swobj, field_val);
             % Test field is set
-            testCase.assertEqual(field(swobj), field_val)
-            % Also test swobj is returned
-            testCase.verify_obj(swobj, new_swobj);
+            testCase.assertEqual(field(testCase.swobj), field_val)
+            % Also test handle to swobj is returned
+            assert (testCase.swobj == new_swobj);
         end
     end
     methods (Test, TestTags = {'Symbolic'})
         function test_set_field_sym_mode_sym_input(testCase)
-            swobj = spinw();
-            swobj.symbolic(true);
+            testCase.swobj.symbolic(true);
             field_val = sym([pi pi/2 pi/3]);
-            field(swobj, field_val);
-            testCase.assertEqual(field(swobj), field_val);
+            field(testCase.swobj, field_val);
+            testCase.assertEqual(field(testCase.swobj), field_val);
         end
         function test_set_field_sym_mode_non_sym_input(testCase)
-            swobj = spinw();
-            swobj.symbolic(true);
+            testCase.swobj.symbolic(true);
             field_val = [pi pi/2 pi/3];
-            field(swobj, field_val);
+            field(testCase.swobj, field_val);
             expected_field_val = field_val*sym('B');
-            testCase.assertEqual(field(swobj), expected_field_val);
+            testCase.assertEqual(field(testCase.swobj), expected_field_val);
         end
     end
 end

--- a/+sw_tests/+unit_tests/unittest_spinw_field.m
+++ b/+sw_tests/+unit_tests/unittest_spinw_field.m
@@ -1,0 +1,59 @@
+classdef unittest_spinw_field < sw_tests.unit_tests.unittest_super
+    methods (Test)
+        function test_incorrect_shape_field_raises_error(testCase)
+            swobj = spinw();
+            testCase.verifyError(...
+                @() field(swobj, [0; 0]), ...
+                'spinw:magfield:ArraySize');
+        end
+        function test_default_field(testCase)
+            swobj = spinw();
+            testCase.assertEqual(field(swobj), [0 0 0]);
+        end
+        function test_set_field(testCase)
+            swobj = spinw();
+            field_val = [1 2 3];
+            field(swobj, field_val);
+            testCase.assertEqual(field(swobj), field_val);
+        end
+        function test_set_field_column_vector(testCase)
+            swobj = spinw();
+            field_val = [1; 2; 3];
+            field(swobj, field_val);
+            testCase.assertEqual(field(swobj), field_val');
+        end
+        function test_set_field_multiple_times(testCase)
+            swobj = spinw();
+            field(swobj, [1 2 3]);
+            new_field_val = [1.5 2.5 -3.5];
+            field(swobj, new_field_val);
+            testCase.assertEqual(field(swobj), new_field_val);
+        end
+        function test_returns_spinw_obj(testCase)
+            swobj = spinw();
+            field_val = [1 2 3];
+            new_swobj = field(swobj, field_val);
+            % Test field is set
+            testCase.assertEqual(field(swobj), field_val)
+            % Also test swobj is returned
+            testCase.verify_obj(swobj, new_swobj);
+        end
+    end
+    methods (Test, TestTags = {'Symbolic'})
+        function test_set_field_sym_mode_sym_input(testCase)
+            swobj = spinw();
+            swobj.symbolic(true);
+            field_val = sym([pi pi/2 pi/3]);
+            field(swobj, field_val);
+            testCase.assertEqual(field(swobj), field_val);
+        end
+        function test_set_field_sym_mode_non_sym_input(testCase)
+            swobj = spinw();
+            swobj.symbolic(true);
+            field_val = [pi pi/2 pi/3];
+            field(swobj, field_val);
+            expected_field_val = field_val*sym('B');
+            testCase.assertEqual(field(swobj), expected_field_val);
+        end
+    end
+end


### PR DESCRIPTION
Decided to do a simple one for once!

I was wondering whether it was quicker to create the `spinw` object as a property in `TestMethodSetup` and copy it (so it doesn't get changed by other tests) or just create a new one for each test. Doing `swobj = spinw();` 100 times takes 0.09 seconds and `swobj2 = copy(swobj);` 100 times takes 0.29 seconds, so if all you're doing is creating the basic object (like I am in these `field` tests) then it is quicker to create it each time. But once you start doing things like adding atoms, generating couplings it's faster to copy the object.

Also, I noticed that the `testCase.assertEqual` has the arguments in order `(actual_value, expected_value)` whereas our `verify_obj` etc. functions have arguments in order `(expected_value, actual_value)`, which is kind of annoying. We may want to fix this before we write too many tests...