### PR TITLE
Test optmagk

### DIFF
--- a/+sw_tests/+unit_tests/unittest_spinw_optmagk.m
+++ b/+sw_tests/+unit_tests/unittest_spinw_optmagk.m
@@ -22,6 +22,11 @@ classdef unittest_spinw_optmagk < sw_tests.unit_tests.unittest_super
         end
     end
     methods (Test)
+        function test_wrong_shape_kbase_raises_error(testCase)
+            testCase.verifyError(...
+                @() testCase.swobj.optmagk('kbase', [1 1 0]), ...
+                'spinw:optmagk:WrongInput');
+        end
         function test_symbolic_warns_returns_nothing(testCase)
             testCase.swobj.addmatrix('label', 'J1', 'value', 1);
             testCase.swobj.addcoupling('mat', 'J1', 'bond', 1);

--- a/+sw_tests/+unit_tests/unittest_spinw_optmagk.m
+++ b/+sw_tests/+unit_tests/unittest_spinw_optmagk.m
@@ -47,5 +47,30 @@ classdef unittest_spinw_optmagk < sw_tests.unit_tests.unittest_super
             testCase.verify_val(testCase.swobj.mag_str, expected_mag_str, ...
                                 'abs_tol', 1e-4);
         end
+        function test_kbase(testCase)
+            % See https://doi.org/10.1103/PhysRevB.59.14367
+            swobj = spinw();
+            swobj.genlattice('lat_const', [3 3 8])
+            swobj.addatom('r',[0; 0; 0],'S',1)
+            swobj.gencoupling();
+            J1 = 1.2;
+            J2 = 1.0;
+            swobj.addmatrix('label', 'J1', 'value', J1);
+            swobj.addmatrix('label', 'J2', 'value', J2);
+            swobj.addcoupling('mat', 'J1', 'bond', 2, 'subidx', 2);
+            swobj.addcoupling('mat', 'J2', 'bond', 1);
+            swobj.optmagk('kbase', [1; 1; 0]);
+
+            expected_k = acos(-J2/(2*J1))/(2*pi);
+            rel_tol = 1e-5;
+            if abs(expected_k - swobj.mag_str.k(1)) > rel_tol*expected_k
+                % If this k doesn't match, try 1-k
+                expected_k = 1 - expected_k; % k and 1-k are degenerate
+            end
+            expected_mag_str = testCase.default_mag_str;
+            expected_mag_str.k = [expected_k; expected_k; 0];
+            testCase.verify_val(swobj.mag_str, expected_mag_str, ...
+                                'rel_tol', rel_tol);
+        end
     end
 end

--- a/+sw_tests/+unit_tests/unittest_spinw_optmagk.m
+++ b/+sw_tests/+unit_tests/unittest_spinw_optmagk.m
@@ -22,7 +22,19 @@ classdef unittest_spinw_optmagk < sw_tests.unit_tests.unittest_super
         end
     end
     methods (Test)
-        function test_fm_optk(testCase)
+        function test_symbolic_warns_returns_nothing(testCase)
+            testCase.swobj.addmatrix('label', 'J1', 'value', 1);
+            testCase.swobj.addcoupling('mat', 'J1', 'bond', 1);
+            testCase.swobj.symbolic(true)
+            testCase.verifyWarning(...
+                @() testCase.swobj.optmagk, ...
+                'spinw:optmagk:NoSymbolic');
+            testCase.verifyEmpty(testCase.swobj.mag_str.k);
+            testCase.verifyEmpty(testCase.swobj.mag_str.F);
+            testCase.verify_val(testCase.swobj.mag_str.nExt, ...
+                                int32([1 1 1]));
+        end
+        function test_fm_chain_optk(testCase)
             testCase.swobj.addmatrix('label', 'J1', 'value', -1);
             testCase.swobj.addcoupling('mat', 'J1', 'bond', 1);
             out = testCase.swobj.optmagk;
@@ -41,7 +53,7 @@ classdef unittest_spinw_optmagk < sw_tests.unit_tests.unittest_super
             testCase.verify_val(testCase.swobj.mag_str, expected_mag_str, ...
                                 'abs_tol', 1e-4);
         end
-        function test_afm_optk(testCase)
+        function test_afm_chain_optk(testCase)
             testCase.swobj.addmatrix('label', 'J1', 'value', 1);
             testCase.swobj.addcoupling('mat', 'J1', 'bond', 1);
             testCase.swobj.optmagk;

--- a/+sw_tests/+unit_tests/unittest_spinw_optmagk.m
+++ b/+sw_tests/+unit_tests/unittest_spinw_optmagk.m
@@ -3,12 +3,14 @@ classdef unittest_spinw_optmagk < sw_tests.unit_tests.unittest_super
 
     properties
         swobj = [];
-        swobj_tri = [];
         % output from optmagk
         default_mag_str = struct('nExt', int32([1 1 1]), ...
+                                 'F', [sqrt(1/3) + 1i*sqrt(1/2); ...
+                                       sqrt(1/3); ...
+                                       sqrt(1/3) - 1i*sqrt(1/2)], ...
                                  'k', [1; 0; 0]);
     end
-    methods (TestClassSetup)
+    methods (TestMethodSetup)
         function setup_chain_model(testCase)            
             testCase.swobj = spinw();
             testCase.swobj.genlattice('lat_const', [3 8 8])
@@ -17,40 +19,31 @@ classdef unittest_spinw_optmagk < sw_tests.unit_tests.unittest_super
         end
     end
     methods (Test)
-        function test_fm_opt(testCase)
+        function test_fm_optk(testCase)
             testCase.swobj.addmatrix('label', 'J1', 'value', -1);
             testCase.swobj.addcoupling('mat', 'J1', 'bond', 1);
             out = testCase.swobj.optmagk;
             out.stat = rmfield(out.stat, 'nFunEvals');
-            k = [1; 0; 0];
-            F = [sqrt(1/3) + 1i*sqrt(1/2); ...
-                 sqrt(1/3); ...
-                 sqrt(1/3) - 1i*sqrt(1/2)];
-            expected_out = struct('k', k, ...
+
+            expected_mag_str = testCase.default_mag_str;
+            expected_out = struct('k', expected_mag_str.k, ...
                                   'E', -1, ....
-                                  'F', F, ...
+                                  'F', expected_mag_str.F, ...
                                   'stat', struct('S', 0, ...
                                                  'exitflag', -1));
             % Test struct output by optmagk
             testCase.verify_val(out, expected_out, 'abs_tol', 1e-4);
             % Also test spinw attributes have been set
             expected_mag_str = testCase.default_mag_str;
-            expected_mag_str.F = F;
             testCase.verify_val(testCase.swobj.mag_str, expected_mag_str, ...
                                 'abs_tol', 1e-4);
         end
-    end
-    methods (Test)
-        function test_afm_opt(testCase)
+        function test_afm_optk(testCase)
             testCase.swobj.addmatrix('label', 'J1', 'value', 1);
             testCase.swobj.addcoupling('mat', 'J1', 'bond', 1);
             testCase.swobj.optmagk;
-            % Also test spinw attributes have been set
             expected_mag_str = testCase.default_mag_str;
             expected_mag_str.k = [0.5; 0; 0];
-            expected_mag_str.F = [sqrt(1/3) + 1i*sqrt(1/2); ...
-                                  sqrt(1/3); ...
-                                  sqrt(1/3) - 1i*sqrt(1/2)];
             testCase.verify_val(testCase.swobj.mag_str, expected_mag_str, ...
                                 'abs_tol', 1e-4);
         end

--- a/+sw_tests/+unit_tests/unittest_spinw_optmagk.m
+++ b/+sw_tests/+unit_tests/unittest_spinw_optmagk.m
@@ -10,6 +10,9 @@ classdef unittest_spinw_optmagk < sw_tests.unit_tests.unittest_super
                                        sqrt(1/3) - 1i*sqrt(1/2)], ...
                                  'k', [1; 0; 0]);
     end
+    properties (TestParameter)
+        kbase_opts = {[1; 1; 0], [1 0; 0 1; 0 0]};
+    end
     methods (TestMethodSetup)
         function setup_chain_model(testCase)            
             testCase.swobj = spinw();
@@ -47,7 +50,7 @@ classdef unittest_spinw_optmagk < sw_tests.unit_tests.unittest_super
             testCase.verify_val(testCase.swobj.mag_str, expected_mag_str, ...
                                 'abs_tol', 1e-4);
         end
-        function test_kbase(testCase)
+        function test_kbase(testCase, kbase_opts)
             % See https://doi.org/10.1103/PhysRevB.59.14367
             swobj = spinw();
             swobj.genlattice('lat_const', [3 3 8])
@@ -59,7 +62,7 @@ classdef unittest_spinw_optmagk < sw_tests.unit_tests.unittest_super
             swobj.addmatrix('label', 'J2', 'value', J2);
             swobj.addcoupling('mat', 'J1', 'bond', 2, 'subidx', 2);
             swobj.addcoupling('mat', 'J2', 'bond', 1);
-            swobj.optmagk('kbase', [1; 1; 0]);
+            swobj.optmagk('kbase', kbase_opts);
 
             expected_k = acos(-J2/(2*J1))/(2*pi);
             rel_tol = 1e-5;

--- a/+sw_tests/+unit_tests/unittest_spinw_optmagk.m
+++ b/+sw_tests/+unit_tests/unittest_spinw_optmagk.m
@@ -1,0 +1,58 @@
+classdef unittest_spinw_optmagk < sw_tests.unit_tests.unittest_super
+    % Runs through unit test for @spinw/spinwave.m
+
+    properties
+        swobj = [];
+        swobj_tri = [];
+        % output from optmagk
+        default_mag_str = struct('nExt', int32([1 1 1]), ...
+                                 'k', [1; 0; 0]);
+    end
+    methods (TestClassSetup)
+        function setup_chain_model(testCase)            
+            testCase.swobj = spinw();
+            testCase.swobj.genlattice('lat_const', [3 8 8])
+            testCase.swobj.addatom('r',[0; 0; 0],'S',1)
+            testCase.swobj.gencoupling();
+        end
+    end
+    methods (Test)
+        function test_fm_opt(testCase)
+            testCase.swobj.addmatrix('label', 'J1', 'value', -1);
+            testCase.swobj.addcoupling('mat', 'J1', 'bond', 1);
+            out = testCase.swobj.optmagk;
+            out.stat = rmfield(out.stat, 'nFunEvals');
+            k = [1; 0; 0];
+            F = [sqrt(1/3) + 1i*sqrt(1/2); ...
+                 sqrt(1/3); ...
+                 sqrt(1/3) - 1i*sqrt(1/2)];
+            expected_out = struct('k', k, ...
+                                  'E', -1, ....
+                                  'F', F, ...
+                                  'stat', struct('S', 0, ...
+                                                 'exitflag', -1));
+            % Test struct output by optmagk
+            testCase.verify_val(out, expected_out, 'abs_tol', 1e-4);
+            % Also test spinw attributes have been set
+            expected_mag_str = testCase.default_mag_str;
+            expected_mag_str.F = F;
+            testCase.verify_val(testCase.swobj.mag_str, expected_mag_str, ...
+                                'abs_tol', 1e-4);
+        end
+    end
+    methods (Test)
+        function test_afm_opt(testCase)
+            testCase.swobj.addmatrix('label', 'J1', 'value', 1);
+            testCase.swobj.addcoupling('mat', 'J1', 'bond', 1);
+            testCase.swobj.optmagk;
+            % Also test spinw attributes have been set
+            expected_mag_str = testCase.default_mag_str;
+            expected_mag_str.k = [0.5; 0; 0];
+            expected_mag_str.F = [sqrt(1/3) + 1i*sqrt(1/2); ...
+                                  sqrt(1/3); ...
+                                  sqrt(1/3) - 1i*sqrt(1/2)];
+            testCase.verify_val(testCase.swobj.mag_str, expected_mag_str, ...
+                                'abs_tol', 1e-4);
+        end
+    end
+end

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -52,6 +52,6 @@ jobs:
         with:
           path: artifacts
       - name: Publish test results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           files: artifacts/**/junit_report*.xml

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -67,3 +67,6 @@ Bug Fixes
   Previously this would've caused a crash.
 - Raise error if invalid shape ``kbase`` is provided to ``optmagk``,
   previously it would be silently set to empty
+- Ensure varargin is correctly passed through to ``ndbase.pso`` from
+  ``optmagk``. Previously user provided ``TolFun``, ``TolX`` and
+  ``MaxIter`` would be overwritten by the defaults.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -65,3 +65,5 @@ Bug Fixes
   mode in ``genmagstr`` (e.g. ``S`` is passed to ``random``)
 - Raise error if complex values is provided for ``n`` in ``genmagstr``.
   Previously this would've caused a crash.
+- Raise error if invalid shape ``kbase`` is provided to ``optmagk``,
+  previously it would be silently set to empty

--- a/swfiles/@spinw/genmagstr.m
+++ b/swfiles/@spinw/genmagstr.m
@@ -226,26 +226,7 @@ inpForm.size   = [inpForm.size   {[3 -7 -6] [1 1] [1 1]  [1 1]     [1 -5]}];
 inpForm.soft   = [inpForm.soft   {true      true  false  false     false }];
 
 param = sw_readparam(inpForm, varargin{:});
-
-% Error if S or k is provided but is empty. This means it has failed the
-% input validation, but hasn't caused an error because soft=True
-err_str = [];
-if isstruct(varargin{1})
-    varargin_struct = varargin{1};
-else
-    varargin_struct = struct(varargin{:});
-end
-varargin_names = fields(varargin_struct);
-if any(strcmpi(varargin_names, 'S')) && isempty(param.S)
-    err_str = ["S"];
-end
-if any(strcmpi(varargin_names, 'k')) && isempty(param.k)
-    err_str = [err_str "k"];
-end
-if length(err_str) > 0
-    error('spinw:genmagstr:WrongInput', 'Incorrect input size for ' + ...
-                                        join(err_str, ', '));
-end
+softparamcheck(["S", "k"], 'genmagstr', param, varargin{:});
 
 if strcmpi(param.mode, 'rotate') && isempty(obj.mag_str.F)
     error('spinw:genmagstr:WrongInput', ['rotate mode requires a magnetic ' ...
@@ -292,7 +273,7 @@ mode_args = struct("random", ["k", "n", "nExt", "unit"], ...
 if ~any(strcmp(fields(mode_args), param.mode))
     error('spinw:genmagstr:WrongMode','Wrong param.mode value!');
 else
-    unused_args = {varargin_names{:}};
+    unused_args = vararginnames(varargin{:});
     unused_args(ismember(lower(unused_args), ["mode" "norm"])) = [];
     unused_args(ismember(lower(unused_args), lower(mode_args.(lower(param.mode))))) = [];
     if ~isempty(unused_args)

--- a/swfiles/@spinw/optmagk.m
+++ b/swfiles/@spinw/optmagk.m
@@ -10,10 +10,9 @@ function result = optmagk(obj,varargin)
 % `res = optmagk(obj,Name,Value)` determines the optimal propagation vector
 % using the Luttinger-Tisza method. It calculates the Fourier transform of
 % the Hamiltonian as a function of wave vector and finds the wave vector
-% that corresponds to the smalles global eigenvalue of the Hamiltonian. It
-% also returns the normal vector that corresponds to the rotating
-% coordinate system. The global optimization is achieved using
-% Particle-Swarm optimizer.
+% that corresponds to the smalles global eigenvalue of the Hamiltonian.
+% The global optimization is achieved using Particle-Swarm optimizer. This
+% function sets k and F in spinw.mag_str, and also returns them.
 % 
 % ### Input Arguments
 % 
@@ -41,8 +40,8 @@ function result = optmagk(obj,varargin)
 % : Structure with the following fields:
 %   * `k`       Value of the optimal k-vector, with values between 0
 %                       and 1/2.
-%   * `n`       Normal vector, defines the rotation axis of the
-%                       rotating coordinate system.
+%   * `F`       Fourier components for every spin in the magnetic
+%                       cell.
 %   * `E`       The most negative eigenvalue at the given propagation
 %                       vector.
 %   * `stat`    Full output of the [ndbase.pso] optimizer.

--- a/swfiles/@spinw/optmagk.m
+++ b/swfiles/@spinw/optmagk.m
@@ -59,6 +59,7 @@ inpForm.soft   = {true   };
 
 warning('off','sw_readparam:UnreadInput')
 param = sw_readparam(inpForm, varargin{:});
+softparamcheck(["kbase"], 'optmagk', param, varargin{:});
 warning('on','sw_readparam:UnreadInput')
 
 

--- a/swfiles/@spinw/optmagk.m
+++ b/swfiles/@spinw/optmagk.m
@@ -126,8 +126,8 @@ kones = ones(1,D);
 
 warning('off','sw_readparam:UnreadInput')
 % optimise the energy using particle swarm
-[pOpt0, ~, ~] = ndbase.pso([],@optfun,1/4*kones,'lb',0*kones,'ub',kones,varargin{:},...
-    'TolFun',1e-5,'TolX',1e-5,'MaxIter',1e3);
+[pOpt0, ~, ~] = ndbase.pso([],@optfun,1/4*kones,'lb',0*kones,'ub',kones,...
+    'TolFun',1e-5,'TolX',1e-5,'MaxIter',1e3, varargin{:});
 warning('on','sw_readparam:UnreadInput')
 
 % generate an R-value

--- a/swfiles/@spinw/private/softparamcheck.m
+++ b/swfiles/@spinw/private/softparamcheck.m
@@ -1,0 +1,34 @@
+function softparamcheck(params_to_check, func_name, param, varargin)
+% Checks if any parameters have been provided in varargin, but set to
+% empty, and raises an error if so. This function is needed because by
+% default 'soft' params will silently be set to empty if their shape is
+% incorrect, causing unexpected behaviour for users.
+%
+% Input:
+%
+% params_to_check    A list of strings of the parameters to check e.g.
+%                    ["S", "k"]
+% func_name          The name of the function this is being called from
+%                    to be used in the error identifier text
+% param              The output of sw_readparam. If an argument exists in
+%                    varargin, but has been set to empty in param, we know
+%                    it has been silently ignored so raise an error
+% varargin           Varargin that was used as input to sw_readparam to
+%                    create param, this should be name-value pairs or a
+%                    struct
+%
+if isempty(varargin)
+    return
+end
+names = vararginnames(varargin{:});
+err_str = [];
+for i = 1:length(params_to_check)
+    if any(strcmpi(names, params_to_check(i))) ...
+       && isempty(param.(params_to_check(i)))
+        err_str = [err_str params_to_check(i)];
+    end
+end
+if ~isempty(err_str) > 0
+    error(['spinw:' char(func_name) ':WrongInput'], ...
+          'Incorrect input size for ' + join(err_str, ', '));
+end

--- a/swfiles/@spinw/private/vararginnames.m
+++ b/swfiles/@spinw/private/vararginnames.m
@@ -1,0 +1,16 @@
+function names = vararginnames(varargin)
+% Given varargin, returns a list of the given
+% argument names (so we know which arguments a user has passed to a function).
+% Note that inputs to SpinW functions can either be name-value pairs or a
+% struct
+%
+% Input:
+%
+% varargin    Variable-length argument list (name value pairs) or struct
+if isstruct(varargin{1})
+    varargin_struct = varargin{1};
+else
+    varargin_struct = struct(varargin{:});
+end
+names = fields(varargin_struct);
+end


### PR DESCRIPTION
This was fairly simple to test, just a few notes:

* This function doesn't support symbolic mode, but instead of raising an error it warns and returns nothing. I would've expected it to error in this case.
* To keep parity with `genmagstr` (which now errors if invalid shape `'S'` or `'k'` is provided rather than silently setting them to empty as before), `optmagk` will now error if incorrect shape `'kbase'` is provided. Rather than duplicate the code from `genmagstr`, I created some new private functions to do this. I made them private so that we can change them later without having to bump the version number. Ideally this functionality should be in `sw_readparam` but that would affect all functions and be a big job and I'm not sure if we're ready to be messing with the overall parameter handling just yet.