### PR TITLE
Update checkout, codecov, and upload-artifacts in actions

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out SpinW
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up MATLAB
         uses: matlab-actions/setup-matlab@v1 # v1.1.0 required for Windows/MacOS support
         with:
@@ -30,14 +30,14 @@ jobs:
         uses: matlab-actions/run-command@v1
         with:
           command: "run run_tests.m"
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         if: ${{ always() && matrix.os == 'ubuntu-latest' && matrix.matlab_version == 'latest' }}
         with:
             files: coverage*.xml
             token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Unit test results ${{ matrix.os }}
           path: junit_report*.xml


### PR DESCRIPTION
See https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/