### PR TITLE
Add test to explicitly check rotc can be an inversion

### DIFF
--- a/+sw_tests/+unit_tests/unittest_spinw_addtwin.m
+++ b/+sw_tests/+unit_tests/unittest_spinw_addtwin.m
@@ -79,6 +79,13 @@ classdef unittest_spinw_addtwin < sw_tests.unit_tests.unittest_super
             testCase.assertEqual(testCase.swobj.twin.rotc(:,:,2:end), rotc)  
         end
         
+        function test_addtwin_support_inversion_rotc(testCase)
+            rotc = -eye(3);
+            testCase.swobj.addtwin('rotc', rotc)
+            testCase.assertEqual(testCase.swobj.twin.vol, [1, 1])
+            testCase.assertEqual(testCase.swobj.twin.rotc(:,:,2:end), rotc)  
+        end
+
         function test_addtwin_overwrite_vol_ratio(testCase)
             testCase.swobj.addtwin('axis', [0,0,1], 'vol', 0.5, ...
                 'overwrite', true)


### PR DESCRIPTION
This could have been combined with test_addtwin_with_multiple_rotc in a parameterized test but I think keeping it separate is preferable because it explicitly documents a requirement - but happy to change!