### PR TITLE
Add mex to spinwave unit tests

### DIFF
--- a/+sw_tests/+unit_tests/unittest_spinw_spinwave.m
+++ b/+sw_tests/+unit_tests/unittest_spinw_spinwave.m
@@ -197,11 +197,7 @@ classdef unittest_spinw_spinwave < sw_tests.unit_tests.unittest_super
             swpref.setpref('usemex', mex);
             sw_out = testCase.swobj.spinwave(testCase.qh5, ...
                                              'saveV', true, 'saveH', true);
-            if mex
-                expected_V = repmat(-eye(2), 1, 1, 5);
-            else
-                expected_V = repmat(eye(2), 1, 1, 5);
-            end
+            expected_V = repmat(eye(2), 1, 1, 5);
             expected_H = zeros(2, 2, 5);
             expected_H(:, :, [2 4]) = 2*repmat(eye(2), 1, 1, 2);
             expected_H(:, :, 3) = 4*eye(2);

--- a/+sw_tests/+unit_tests/unittest_spinw_spinwave.m
+++ b/+sw_tests/+unit_tests/unittest_spinw_spinwave.m
@@ -53,6 +53,17 @@ classdef unittest_spinw_spinwave < sw_tests.unit_tests.unittest_super
             testCase.swobj_tri.addcoupling('mat','J1','bond',1);
         end
     end
+    methods (TestMethodSetup)
+        function disable_mex_setup(testCase)
+            swpref.setpref('usemex', false);
+        end
+    end
+    methods (TestMethodTeardown)
+        function disable_mex_teardown(testCase)
+            swpref.setpref('usemex', false);
+        end
+    end
+
     methods
         function sw = get_expected_sw_qh5(testCase)
             % Expected output for the chain model for 5 q-points from

--- a/+sw_tests/+unit_tests/unittest_spinw_spinwave.m
+++ b/+sw_tests/+unit_tests/unittest_spinw_spinwave.m
@@ -254,7 +254,7 @@ classdef unittest_spinw_spinwave < sw_tests.unit_tests.unittest_super
             fe_cu_chain.addcoupling('mat','J_{Cu-Fe}','bond',[4 5]);
             fe_cu_chain.genmagstr('mode','helical','S',[0 0;1 1;0 0],'k',[1/2 0 0])
 
-            sw_out = fe_cu_chain.spinwave(testCase.qh5, 'sortMode', false);
+            sw_out = fe_cu_chain.spinwave(testCase.qh5, 'sortMode', false, 'omega_tol', 1e-12);
             om1 = 4.11473;
             om2 = 1.36015;
             om3 = 1.38527;

--- a/+sw_tests/+unit_tests/unittest_spinw_spinwave.m
+++ b/+sw_tests/+unit_tests/unittest_spinw_spinwave.m
@@ -25,6 +25,7 @@ classdef unittest_spinw_spinwave < sw_tests.unit_tests.unittest_super
         % Test directions and literal qpts work
         qpts_h5 = {{[0 0 0], [1 0 0], 5}, ...
                    [0:0.25:1; zeros(2,5)]};
+        mex = {0, 1};
     end
 
     methods (TestClassSetup)
@@ -140,12 +141,14 @@ classdef unittest_spinw_spinwave < sw_tests.unit_tests.unittest_super
         end
     end
     methods (Test)
-        function test_sw_qh5(testCase, qpts_h5)
+        function test_sw_qh5(testCase, qpts_h5, mex)
+            swpref.setpref('usemex', mex);
             sw_out = testCase.swobj.spinwave(qpts_h5);
             expected_sw = testCase.get_expected_sw_qh5();
             testCase.verify_spinwave(sw_out, expected_sw);
         end
-        function test_sw_qh5_sortmode(testCase)
+        function test_sw_qh5_sortmode(testCase, mex)
+            swpref.setpref('usemex', mex);
             sw_out = testCase.swobj.spinwave(testCase.qh5, 'sortMode', false);
             expected_sw = testCase.get_expected_sw_qh5();
             % Sortmode swaps the last 2 modes
@@ -154,7 +157,8 @@ classdef unittest_spinw_spinwave < sw_tests.unit_tests.unittest_super
             expected_sw.param.sortMode = false;
             testCase.verify_spinwave(sw_out, expected_sw);
         end
-        function test_sw_qh5_nformula(testCase)
+        function test_sw_qh5_nformula(testCase, mex)
+            swpref.setpref('usemex', mex);
             % Create copy to avoid changing obj for other tests
             swobj = copy(testCase.swobj);
             nformula = int32(2);
@@ -166,7 +170,8 @@ classdef unittest_spinw_spinwave < sw_tests.unit_tests.unittest_super
             expected_sw.nformula = nformula;
             testCase.verify_spinwave(sw_out_nformula, expected_sw);
         end
-        function test_sw_qh5_periodic(testCase)
+        function test_sw_qh5_periodic(testCase, mex)
+            swpref.setpref('usemex', mex);
             % Test qpts in different BZ give same omega, Sab
             qpts = testCase.qh5 + 1;
             sw_out = testCase.swobj.spinwave(qpts);
@@ -175,7 +180,8 @@ classdef unittest_spinw_spinwave < sw_tests.unit_tests.unittest_super
             expected_sw.hklA =  [qpts(1, :)*2/3; qpts(2:end, :)*0.25 ]*pi;
             testCase.verify_spinwave(sw_out, expected_sw);
         end
-        function test_sw_qh5_perpendicular(testCase)
+        function test_sw_qh5_perpendicular(testCase, mex)
+            swpref.setpref('usemex', mex);
             % Test qpts in perpendicular direction give flat modes
             qpts = [zeros(1, 5); 0:0.25:1; 0:0.25:1];
             sw_out = testCase.swobj.spinwave(qpts);
@@ -187,10 +193,15 @@ classdef unittest_spinw_spinwave < sw_tests.unit_tests.unittest_super
             expected_sw.Sab(3, 1, :, 5) = -expected_sw.Sab(3, 1, :, 5);
             testCase.verify_spinwave(sw_out, expected_sw);
         end
-        function test_sw_qh5_saveH_saveV(testCase)
+        function test_sw_qh5_saveH_saveV(testCase, mex)
+            swpref.setpref('usemex', mex);
             sw_out = testCase.swobj.spinwave(testCase.qh5, ...
                                              'saveV', true, 'saveH', true);
-            expected_V = repmat(eye(2), 1, 1, 5);
+            if mex
+                expected_V = repmat(-eye(2), 1, 1, 5);
+            else
+                expected_V = repmat(eye(2), 1, 1, 5);
+            end
             expected_H = zeros(2, 2, 5);
             expected_H(:, :, [2 4]) = 2*repmat(eye(2), 1, 1, 2);
             expected_H(:, :, 3) = 4*eye(2);
@@ -200,14 +211,16 @@ classdef unittest_spinw_spinwave < sw_tests.unit_tests.unittest_super
             expected_sw.H = expected_H;
             testCase.verify_spinwave(sw_out, expected_sw);
         end
-        function test_sw_qh5_title(testCase)
+        function test_sw_qh5_title(testCase, mex)
+            swpref.setpref('usemex', mex);
             title = 'Example title';
             sw_out = testCase.swobj.spinwave(testCase.qh5, 'title', title);
             expected_sw = testCase.get_expected_sw_qh5();
             expected_sw.title = title;
             testCase.verify_spinwave(sw_out, expected_sw);
         end
-        function test_sw_with_nExt(testCase)
+        function test_sw_with_nExt(testCase, mex)
+            swpref.setpref('usemex', mex);
             % Create copy to avoid changing obj for other tests
             afm_chain = copy(testCase.swobj);
             afm_chain.matrix.mat = eye(3);
@@ -219,7 +232,8 @@ classdef unittest_spinw_spinwave < sw_tests.unit_tests.unittest_super
             expected_omega = [omega_vals; omega_vals; -omega_vals; -omega_vals];
             testCase.verify_val(sw_afm.omega, expected_omega, 'abs_tol', 1e-7);
         end
-        function test_sw_with_multiple_matom(testCase)
+        function test_sw_with_multiple_matom(testCase, mex)
+            swpref.setpref('usemex', mex);
             fe_cu_chain = spinw;
             fe_cu_chain.genlattice('lat_const', [3 8 4], 'sym', 'P 1');
             fe_cu_chain.addatom('label', 'MCu2', 'r', [0 0 0]);
@@ -243,13 +257,15 @@ classdef unittest_spinw_spinwave < sw_tests.unit_tests.unittest_super
             expected_omega(7:end, :) = -expected_omega(6:-1:1, :);
             testCase.verify_val(sw_out.omega, expected_omega, 'abs_tol', 5e-6);
         end
-        function test_sw_saveSabp_commensurate_warns(testCase)
+        function test_sw_saveSabp_commensurate_warns(testCase, mex)
+            swpref.setpref('usemex', mex);
             sw = testCase.verifyWarning(...
                 @() testCase.swobj.spinwave(testCase.qh5, 'saveSabp', true), ...
                 'spinw:spinwave:CommensurateSabp');
             testCase.verify_spinwave(sw, testCase.get_expected_sw_qh5);
         end
-        function test_sw_incom_in_supercell_warns(testCase)
+        function test_sw_incom_in_supercell_warns(testCase, mex)
+            swpref.setpref('usemex', mex);
             cycloid = spinw;
             cycloid.genlattice('lat_const',[3 8 10], 'sym',0);
             cycloid.addatom('r',[0 0 0],'S',1,'label','Cu1');
@@ -265,7 +281,8 @@ classdef unittest_spinw_spinwave < sw_tests.unit_tests.unittest_super
                                                          30}), ...
                                    'spinw:spinwave:IncommKinSupercell');
         end
-        function test_sw_qh5_saveSabp_incommensurate(testCase)
+        function test_sw_qh5_saveSabp_incommensurate(testCase, mex)
+            swpref.setpref('usemex', mex);
              qpts = testCase.qh5;
              sw_out = testCase.swobj_tri.spinwave(qpts, ...
                                                   'saveSabp', true);
@@ -283,7 +300,8 @@ classdef unittest_spinw_spinwave < sw_tests.unit_tests.unittest_super
              testCase.verify_val(sw_out.Sabp, expected_Sabp, 'rel_tol', 1e-5);
              testCase.verify_val(sw_out.omegap, expected_omegap, 'rel_tol', 1e-5);
         end
-        function test_sw_qh5_fitmode(testCase)
+        function test_sw_qh5_fitmode(testCase, mex)
+            swpref.setpref('usemex', mex);
             qpts = testCase.qh5;
             sw_out = testCase.swobj.spinwave(qpts, 'fitmode', true);
             % fitmode automatically turns off sortMode
@@ -291,7 +309,13 @@ classdef unittest_spinw_spinwave < sw_tests.unit_tests.unittest_super
             expected_sw = rmfield(expected_sw, {'obj', 'datestart', 'dateend'});
             testCase.verify_spinwave(sw_out, expected_sw);
         end
-        function test_incommensurate(testCase)
+        function test_incommensurate(testCase, mex)
+            swpref.setpref('usemex', mex);
+            if mex
+                err ='chol_omp:notposdef';
+            else
+                err= 'spinw:spinwave:NonPosDefHamiltonian';
+            end
             % Tests that incommensurate calculation is ok
             hkl = {[0 0 0] [0 1 0] [1 0 0] 5};
             % Create copy to avoid changing obj for other tests
@@ -302,9 +326,7 @@ classdef unittest_spinw_spinwave < sw_tests.unit_tests.unittest_super
             % neighbour interactions
             swobj.genmagstr('mode', 'helical', 'k', [0.25 0 0], ...
                             'n', [0 0 1], 'S', [1; 0; 0]);
-            testCase.verifyError(...
-                @() swobj.spinwave(hkl),...
-                'spinw:spinwave:NonPosDefHamiltonian');
+            testCase.verifyError(@() swobj.spinwave(hkl), err);
             % Add 2nd neighbour interactions and test this incommensurate
             % structure produces 3x number of modes as commensurate
             swobj.addmatrix('value', 2, 'label', 'Jb');
@@ -313,7 +335,8 @@ classdef unittest_spinw_spinwave < sw_tests.unit_tests.unittest_super
             testCase.assertEqual(size(incomm_spec.omega, 1), ...
                                  size(commensurate_spec.omega, 1) * 3);
         end
-        function test_twin(testCase)
+        function test_twin(testCase, mex)
+            swpref.setpref('usemex', mex);
             % Tests that setting twins gives correct outputs
             % Create copy to avoid changing obj for other tests
             swobj_twin = copy(testCase.swobj);
@@ -346,7 +369,8 @@ classdef unittest_spinw_spinwave < sw_tests.unit_tests.unittest_super
             end
             testCase.verify_spinwave(sw_out, expected_sw);
         end
-        function test_notwin(testCase)
+        function test_notwin(testCase, mex)
+            swpref.setpref('usemex', mex);
             % Create copy to avoid changing obj for other tests
             swobj_twin = copy(testCase.swobj);
             swobj_twin.addtwin('axis', [0 0 1], 'phid', [60 120], 'vol', [1 2]);
@@ -358,7 +382,8 @@ classdef unittest_spinw_spinwave < sw_tests.unit_tests.unittest_super
             expected_sw.obj.twin = swobj_twin.twin;
             testCase.verify_spinwave(sw_out, expected_sw);
         end
-        function test_cmplxBase_equivalent_with_tri(testCase)
+        function test_cmplxBase_equivalent_with_tri(testCase, mex)
+            swpref.setpref('usemex', mex);
             % For this structure, both cmplxBase true and false give the
             % same e-vectors so should give the same result
             qpts = {[0 0 0], [1 0 0], 5};
@@ -366,15 +391,22 @@ classdef unittest_spinw_spinwave < sw_tests.unit_tests.unittest_super
             sw_out_cmplx = testCase.swobj_tri.spinwave(qpts, 'cmplxBase', true);
             testCase.verify_spinwave(sw_out_cmplx, sw_out);
         end
-        function test_cmplxBase_fails_with_chain(testCase)
+        function test_cmplxBase_fails_with_chain(testCase, mex)
+            swpref.setpref('usemex', mex);
+            if mex
+                err ='chol_omp:notposdef';
+            else
+                err= 'spinw:spinwave:NonPosDefHamiltonian';
+            end
             % Test cmplxBase actually does something - it should fail with
             % chain
             qpts = {[0 0 0], [1 0 0], 5};
             testCase.verifyError(...
                 @() testCase.swobj.spinwave(qpts, 'cmplxBase', true), ...
-                'spinw:spinwave:NonPosDefHamiltonian');
+                err);
         end
-        function test_formfact(testCase)
+        function test_formfact(testCase, mex)
+            swpref.setpref('usemex', mex);
             qpts = {[0 0 0] [10 5 1] 19};
             sw_ff = testCase.swobj.spinwave(qpts, 'formfact', true);
             % Test that Sab with the form factor (ff) is explicitly the
@@ -387,7 +419,8 @@ classdef unittest_spinw_spinwave < sw_tests.unit_tests.unittest_super
 
             testCase.verify_spinwave(sw_ff, expected_sw);
         end
-        function test_formfactfun(testCase)
+        function test_formfactfun(testCase, mex)
+            swpref.setpref('usemex', mex);
             function F = formfactfun(atom_label, Q)
                 F = sum(Q, 1);
             end
@@ -403,7 +436,8 @@ classdef unittest_spinw_spinwave < sw_tests.unit_tests.unittest_super
 
             testCase.verify_spinwave(sw_ff, expected_sw, 'rel_tol', 1e-15);
         end
-        function test_gtensor(testCase)
+        function test_gtensor(testCase, mex)
+            swpref.setpref('usemex', mex);
             qpts = {[0 0 0], [1 1 1], 5};
             gmat = diag([1, 2, 3]);
             % Create copy to avoid changing obj for other tests
@@ -419,7 +453,8 @@ classdef unittest_spinw_spinwave < sw_tests.unit_tests.unittest_super
             expected_sw.gtensor = true;
             testCase.verify_spinwave(sw_g, expected_sw);
         end
-        function test_gtensor_incomm(testCase)
+        function test_gtensor_incomm(testCase, mex)
+            swpref.setpref('usemex', mex);
             qpts = {[0 0 0], [1 1 1], 5};
             gmat = diag([1, 2, 3]);
             % Create copy to avoid changing obj for other tests
@@ -436,7 +471,8 @@ classdef unittest_spinw_spinwave < sw_tests.unit_tests.unittest_super
             expected_sw.gtensor = true;
             testCase.verify_spinwave(sw_g, expected_sw, 'rel_tol', 1e-15);
         end
-        function test_hermit(testCase)
+        function test_hermit(testCase, mex)
+            swpref.setpref('usemex', mex);
             % Create copy to avoid changing obj for other tests
             swobj_h = copy(testCase.swobj);
             % Tests that the 'hermit' option to switch to a non-hermitian calculation works
@@ -450,17 +486,20 @@ classdef unittest_spinw_spinwave < sw_tests.unit_tests.unittest_super
             spec = swobj_h.spinwave(hkl, 'hermit', false);
             testCase.assertGreaterThan(sum(abs(imag(spec.omega(:)))), 0);
         end
-        function test_sw_qh5_tol(testCase)
+        function test_sw_qh5_tol(testCase, mex)
+            swpref.setpref('usemex', mex);
             tol = 5e-4;
             qpts = testCase.qh5;
             swobj_tol = copy(testCase.swobj);
             % Generate magstr that deviates slightly from commensurate
             swobj_tol.genmagstr('mode', 'helical', 'k', [tol 0 0], ...
                                 'n', [0 0 1], 'S', [0; 1; 0]);
-            % Check that without tol it is incommensurate - causes error
-            testCase.verifyError(...
-                @() swobj_tol.spinwave(qpts), ...
-                'spinw:spinwave:NonPosDefHamiltonian');
+            if ~mex
+                % Check that without tol it is incommensurate - causes error
+                testCase.verifyError(...
+                    @() swobj_tol.spinwave(qpts), ...
+                    'spinw:spinwave:NonPosDefHamiltonian');
+            end
             % Check that with tol is approximated to commensurate
             sw_out = swobj_tol.spinwave(qpts, 'tol', tol);
             expected_sw = testCase.get_expected_sw_qh5;
@@ -468,13 +507,19 @@ classdef unittest_spinw_spinwave < sw_tests.unit_tests.unittest_super
             expected_sw.param.tol = tol;
             testCase.verify_spinwave(sw_out, expected_sw);
         end
-        function test_sw_qh5_omega_tol(testCase)
+        function test_sw_qh5_omega_tol(testCase, mex)
+            swpref.setpref('usemex', mex);
+            if mex
+                err ='chol_omp:notposdef';
+            else
+                err= 'spinw:spinwave:NonPosDefHamiltonian';
+            end
             qpts = testCase.qh5;
             % Check that with no added omega_tol Hamiltonian isn't positive
             % definite - causes error
             testCase.verifyError(...
                 @() testCase.swobj.spinwave(qpts, 'omega_tol', 0), ...
-                'spinw:spinwave:NonPosDefHamiltonian');
+                err);
             % Check with omega_tol the omega is changed appropriately
             omega_tol = 1;
             sw_out = testCase.swobj.spinwave(qpts, 'omega_tol', omega_tol);

--- a/+sw_tests/+unit_tests/unittest_super.m
+++ b/+sw_tests/+unit_tests/unittest_super.m
@@ -71,7 +71,7 @@ classdef unittest_super < matlab.mock.TestCase
             % List of fields to test separately, only remove fields that
             % exist
             rmfields = intersect(fields(expected_spinwave), ...
-                                 {'datestart', 'dateend', 'obj'});
+                                 {'datestart', 'dateend', 'obj', 'V'});
             testCase.verify_obj(rmfield(actual_spinwave, rmfields), ...
                                 rmfield(expected_spinwave, rmfields), varargin{:})
             for field = ["datestart", "dateend"]
@@ -83,6 +83,21 @@ classdef unittest_super < matlab.mock.TestCase
             % true)
             if isfield(expected_spinwave, 'obj')
                 testCase.verify_obj(actual_spinwave.obj, expected_spinwave.obj);
+            end
+            % verify abs of V (matrix of eigenvecs) - sign doesn't matter
+            % get sign by comaparing max abs value
+            if isfield(expected_spinwave, 'V')
+                ifinite = find(isfinite(expected_spinwave.V));
+                [~, imax] = max(abs(expected_spinwave.V(ifinite)));
+                imax = ifinite(imax); % get index in array incl. non-finite
+                scale_sign = sign(expected_spinwave.V(imax)./actual_spinwave.V(imax));
+                if ~isfinite(scale_sign)
+                    % in case actual V(imax) is not finite - verify should fail!
+                    scale_sign = 1;
+                end
+                testCase.verify_val(actual_spinwave.V, ...
+                                    scale_sign.*expected_spinwave.V,...
+                                    varargin{:});
             end
         end
     end

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -17,6 +17,8 @@ jobs:
         include:
           - os: ubuntu-latest
             matlab_version: R2020a
+          - os: macos-latest
+            INSTALL_DEPS: brew install llvm libomp
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/run_tests.m
+++ b/run_tests.m
@@ -33,6 +33,9 @@ function result = run_tests(out_dir)
     end
     runner = TestRunner.withTextOutput;
 
+    % compile mex files
+    sw_mex('compile', true, 'test', false, 'swtest', false);
+    
     % Add coverage output
     cov_dirs = {'swfiles', 'external'};
     for i = 1:length(cov_dirs)

--- a/swfiles/@spinw/spinwave.m
+++ b/swfiles/@spinw/spinwave.m
@@ -799,29 +799,61 @@ for jj = 1:nSlice
         if useMex && nHklMEM>1
             % use mex files to speed up the calculation
             % mex file will return an error if the matrix is not positive definite.
-            do_chol = true;
-            itry = 0;
-            while do_chol && itry < 1
-                [K2, invK] = chol_omp(ham,'Colpa','tol',param.omega_tol);
-                do_chol = any(~isfinite(K2(:)));
-                itry = itry + 1;
+            [K2, invK] = chol_omp(ham,'Colpa','tol',param.omega_tol);
+            [V, omega(:,hklIdxMEM)] = eig_omp(K2,'sort','descend');
+            % the inverse of the para-unitary transformation V
+            for ii = 1:nHklMEM
+                V(:,:,ii) = V(:,:,ii)*diag(sqrt(gCommd.*omega(:,hklIdxMEM(ii))));
             end
-            if do_chol
-                warning('spinw:spinwave:chol_omp', ...
-                       ['Cholesky factorization with mex enabled has' ...
-                        'failed - attempting calculation without mex.'])
-                [warn1, omega, V] = calc_hermit_magnon_modes(ham, omega, V, gComm, gCommd, nHklMEM, hklIdxMEM, nMagExt, param);
-            else
-                [V, omega(:,hklIdxMEM)] = eig_omp(K2,'sort','descend');
-                % the inverse of the para-unitary transformation V
-                for ii = 1:nHklMEM
-                    V(:,:,ii) = V(:,:,ii)*diag(sqrt(gCommd.*omega(:,hklIdxMEM(ii))));
-                end
-                % V = bsxfun(@times,invK,V);
-                V = sw_mtimesx(invK,V);
-            end
+            % V = bsxfun(@times,invK,V);
+            V = sw_mtimesx(invK,V);
         else
-            [warn1, omega, V] = calc_hermit_magnon_modes(ham, omega, V, gComm, gCommd, nHklMEM, hklIdxMEM, nMagExt, param);
+            for ii = 1:nHklMEM
+                [K, posDef]  = chol(ham(:,:,ii));
+                if posDef > 0
+                    try
+                        % get tolerance from smallest negative eigenvalue
+                        tol0 = eig(ham(:,:,ii));
+                        tol0 = sort(real(tol0));
+                        tol0 = abs(tol0(1));
+                        % TODO determine the right tolerance value
+                        tol0 = tol0*sqrt(nMagExt*2)*4;
+                        if tol0>param.omega_tol
+                            error('spinw:spinwave:NonPosDefHamiltonian','Very baaaad!');
+                        end
+                        try
+                            K = chol(ham(:,:,ii)+eye(2*nMagExt)*tol0);
+                        catch
+                            K = chol(ham(:,:,ii)+eye(2*nMagExt)*param.omega_tol);
+                        end
+                        warn1 = true;
+                    catch PD
+                        if param.tid == 2
+                            % close timer window
+                            sw_timeit(100,2,param.tid);
+                        end
+                        error('spinw:spinwave:NonPosDefHamiltonian',...
+                            ['Hamiltonian matrix is not positive definite, probably'...
+                            ' the magnetic structure is wrong! For approximate'...
+                            ' diagonalization try the param.hermit=false option']);
+                    end
+                end
+
+                K2 = K*gComm*K';
+                K2 = 1/2*(K2+K2');
+                % Hermitian K2 will give orthogonal eigenvectors
+                [U, D] = eig(K2);
+                D      = diag(D);
+
+                % sort modes accordign to the real part of the energy
+                [~, idx] = sort(real(D),'descend');
+                U = U(:,idx);
+                % omega dispersion
+                omega(:, hklIdxMEM(ii)) = D(idx);
+
+                % the inverse of the para-unitary transformation V
+                V(:,:,ii) = inv(K)*U*diag(sqrt(gCommd.*omega(:, hklIdxMEM(ii)))); %#ok<MINV>
+            end
         end
     else
         % All the matrix calculations are according to White's paper
@@ -1058,56 +1090,4 @@ if strcmp(singWarn,'MATLAB:nearlySingularMatrix')
             'to singular or badly scaled. Results may be inaccurate.']);
 end
 
-end
-
-
-function [warn1, omega, V] = calc_hermit_magnon_modes(ham, omega, V, gComm, gCommd, nHklMEM, hklIdxMEM, nMagExt, param)           
-    warn1 = false;
-    for ii = 1:nHklMEM
-        [K, posDef]  = chol(ham(:,:,ii));
-        if posDef > 0
-            try
-                % get tolerance from smallest negative eigenvalue
-                tol0 = eig(ham(:,:,ii));
-                tol0 = sort(real(tol0));
-                tol0 = abs(tol0(1));
-                % TODO determine the right tolerance value
-                tol0 = tol0*sqrt(nMagExt*2)*4;
-                if tol0>param.omega_tol
-                    error('spinw:spinwave:NonPosDefHamiltonian','Very baaaad!');
-                end
-                try
-                    K = chol(ham(:,:,ii)+eye(2*nMagExt)*tol0);
-                catch
-                    K = chol(ham(:,:,ii)+eye(2*nMagExt)*param.omega_tol);
-                end
-                warn1 = true;
-            catch PD
-                if param.tid == 2
-                    % close timer window
-                    sw_timeit(100,2, param.tid);
-                end
-                error('spinw:spinwave:NonPosDefHamiltonian',...
-                    ['Hamiltonian matrix is not positive definite, probably'...
-                    ' the magnetic structure is wrong! For approximate'...
-                    ' diagonalization try the param.hermit=false option']);
-            end
-        end
-        
-        K2 = K*gComm*K';
-        K2 = 1/2*(K2+K2');
-
-        % Hermitian K2 will give orthogonal eigenvectors
-        [U, D] = eig(K2);
-        D      = diag(D);
-        
-        % sort modes accordign to the real part of the energy
-        [~, idx] = sort(real(D),'descend');
-        U = U(:,idx);
-        % omega dispersion
-        omega(:, hklIdxMEM(ii)) = D(idx);
-        
-        % the inverse of the para-unitary transformation V
-        V(:,:,ii) = inv(K)*U*diag(sqrt(gCommd.*omega(:, hklIdxMEM(ii)))); %#ok<MINV>
-    end
 end

--- a/swfiles/sw_mex.m
+++ b/swfiles/sw_mex.m
@@ -59,11 +59,17 @@ if param.compile
     elseif ismac
         % add =libiomp5 after -fopenmp?
         cd(eig_omp_dir);
-        mex('-v','-largeArrayDims','eig_omp.cpp','-lmwlapack','COMPFLAGS="/openmp $COMPFLAGS"','CXXFLAGS=$CXXFLAGS -fopenmp -pthread');
+        mex('-v','-largeArrayDims','eig_omp.cpp', 'CXX_FLAGS="-Xclang -fopenmp -pthread"', ...
+            'LDFLAGS="$LDFLAGS -L$MATLABROOT/sys/os/maci64 -liomp5 -lmwblas -lmwlapack"', ...
+            'CXXOPTIMFLAGS="$CXXOPTIMFLAGS -Xclang -fopenmp"', "-I/usr/local/opt/libomp/include");
         cd(chol_omp_dir);
-        mex('-v','-largeArrayDims','chol_omp.cpp','-lmwlapack','-lmwblas','COMPFLAGS="/openmp $COMPFLAGS"','CXXFLAGS=$CXXFLAGS -fopenmp -pthread');
+        mex('-v','-largeArrayDims','chol_omp.cpp', 'CXX_FLAGS="-Xclang -fopenmp -pthread"', ...
+            'LDFLAGS="$LDFLAGS -L$MATLABROOT/sys/os/maci64 -liomp5 -lmwblas -lmwlapack"', ...
+            'CXXOPTIMFLAGS="$CXXOPTIMFLAGS -Xclang -fopenmp"', "-I/usr/local/opt/libomp/include");
         cd(mtimesx_dir);
-        mex('-DDEFINEUNIX','-largeArrayDims','sw_mtimesx.c','-lmwblas');
+        mex('-v','-largeArrayDims','sw_mtimesx.c', 'CXX_FLAGS="-Xclang -fopenmp -pthread"', ...
+            'LDFLAGS="$LDFLAGS -L$MATLABROOT/sys/os/maci64 -liomp5 -lmwblas"', ...
+            'CXXOPTIMFLAGS="$CXXOPTIMFLAGS -Xclang -fopenmp"', "-I/usr/local/opt/libomp/include");
     else
         % linux?
         cd(eig_omp_dir);


### PR DESCRIPTION
Make spinwave unit tests parameterised - looping over mex disabled/enabled.
Note minor tests with input validation, file writing etc. are runnign with mex disabled.

Have found 3 flaky tests:
```
     Name                                                                                    Failed  Incomplete  Reason(s)
    =====================================================================================================================================
     sw_tests.unit_tests.unittest_spinw_spinwave/test_sw_qh5_saveSabp_incommensurate(mex=1)    X                 Failed by verification.
    -------------------------------------------------------------------------------------------------------------------------------------
     sw_tests.unit_tests.unittest_spinw_spinwave/test_cmplxBase_equivalent_with_tri(mex=1)     X         X       Errored.
    -------------------------------------------------------------------------------------------------------------------------------------
     sw_tests.unit_tests.unittest_spinw_spinwave/test_gtensor_incomm(mex=1)                    X                 Failed by verification. 
```
They fail ~1/3 times
