### PR TITLE
Fix out-of-memory error in mmat

### DIFF
--- a/+sw_tests/+unit_tests/unittest_mmat.m
+++ b/+sw_tests/+unit_tests/unittest_mmat.m
@@ -1,0 +1,26 @@
+classdef unittest_mmat < sw_tests.unit_tests.unittest_super
+    % Runs through unit test for sw_neutron.m
+
+    properties
+        swobj = [];
+    end
+
+    methods (Test)
+        function test_mmat_branch(testCase)
+            matA = rand(15,10);
+            matB = rand(10,5,100);
+            % Run it normally
+            mat0 = mmat(matA, matB);
+            % Force sw_freemem to return only 100 bytes available
+            mock_freemem = sw_tests.utilities.mock_function('sw_freemem', 100);
+            % Checks that with low memory the routine actually does not call bsxfun
+            mock_bsxfun = sw_tests.utilities.mock_function('bsxfunsym');
+            mat1 = mmat(matA, matB);
+            testCase.verify_val(mat0, mat1, 'rel_tol', 0.01, 'abs_tol', 1e-6);
+            testCase.assertEqual(mock_freemem.n_calls, 1);
+            testCase.assertEqual(mock_bsxfun.n_calls, 0);
+        end
+    end
+
+end
+

--- a/+sw_tests/+unit_tests/unittest_spinw_spinwave.m
+++ b/+sw_tests/+unit_tests/unittest_spinw_spinwave.m
@@ -103,7 +103,7 @@ classdef unittest_spinw_spinwave < sw_tests.unit_tests.unittest_super
         function test_sw_qh5_zero_freemem_warns(testCase)
             % Mock sw_freemem to return 0 to trigger warning
             sw_freemem_mock = sw_tests.utilities.mock_function( ...
-                'sw_freemem', '0');
+                'sw_freemem', 0);
             sw_out = testCase.verifyWarning(...
                 @() testCase.swobj.spinwave(testCase.qh5), ...
                 'spinw:spinwave:FreeMemSize');
@@ -112,7 +112,7 @@ classdef unittest_spinw_spinwave < sw_tests.unit_tests.unittest_super
         function test_sw_qh5_low_freemem(testCase)
             % Check with low free memory calculation still attempted
             sw_freemem_mock = sw_tests.utilities.mock_function( ...
-                'sw_freemem', '100');
+                'sw_freemem', 100);
             sw_out = testCase.swobj.spinwave(testCase.qh5);
             testCase.verify_spinwave(sw_out, testCase.get_expected_sw_qh5);
         end

--- a/+sw_tests/+utilities/mock_function.m
+++ b/+sw_tests/+utilities/mock_function.m
@@ -12,13 +12,16 @@ classdef mock_function < handle
                 return_value = '{[]}';
             else
                 global mock_ret_val;
+                if isempty(mock_ret_val)
+                    mock_ret_val = struct();
+                end
                 if iscell(return_value)
-                    mock_ret_val = return_value;
+                    mock_ret_val.(function_name) = return_value;
                 else
-                    mock_ret_val = {return_value};
+                    mock_ret_val.(function_name) = {return_value};
                 end
                 rv_str = 'global mock_ret_val;';
-                return_value = 'mock_ret_val';
+                return_value = ['mock_ret_val.' function_name];
             end
             fnstr = [...
                      'function varargout = %s(varargin)\n' ...
@@ -53,6 +56,10 @@ classdef mock_function < handle
         end
         function delete(mockobj)
             delete(mockobj.filename);
+            global mock_ret_val;
+            if isfield(mock_ret_val, mockobj.func)
+                mock_ret_val = rmfield(mock_ret_val, mockobj.func);
+            end
         end
         function n_call = get.n_calls(mockobj)
             [n_call, ~] = feval(mockobj.func, 'check_calls');

--- a/+sw_tests/+utilities/mock_function.m
+++ b/+sw_tests/+utilities/mock_function.m
@@ -8,12 +8,23 @@ classdef mock_function < handle
     methods
         function mockobj = mock_function(function_name, return_value)
             if nargin < 2
-                return_value = '[]';
+                rv_str = '';
+                return_value = '{[]}';
+            else
+                global mock_ret_val;
+                if iscell(return_value)
+                    mock_ret_val = return_value;
+                else
+                    mock_ret_val = {return_value};
+                end
+                rv_str = 'global mock_ret_val;';
+                return_value = 'mock_ret_val';
             end
             fnstr = [...
                      'function varargout = %s(varargin)\n' ...
                      '    persistent n_calls;\n' ...
                      '    persistent arguments;\n' ...
+                     '    %s\n' ...
                      '    if nargin > 0 && ischar(varargin{1}) && strcmp(varargin{1}, ''check_calls'')\n' ...
                      '        varargout = {n_calls arguments};\n' ...
                      '        return;\n' ...
@@ -26,13 +37,13 @@ classdef mock_function < handle
                      '        arguments = [arguments {varargin}];\n' ...
                      '    end\n' ...
                      '    if nargout > 0\n' ...
-                     '        varargout = {%s};\n' ...
+                     '        varargout = %s;\n' ...
                      '    end\n' ...
                      'end\n'];
             mockobj.func = function_name;
             mockobj.filename = sprintf('%s.m', function_name);
             fid = fopen(mockobj.filename, 'w');
-            fprintf(fid, fnstr, function_name, return_value);
+            fprintf(fid, fnstr, function_name, rv_str, return_value);
             fclose(fid);
             whichfun = which(function_name);
             while ~strcmp(whichfun, fullfile(pwd, mockobj.filename))
@@ -45,10 +56,12 @@ classdef mock_function < handle
         end
         function n_call = get.n_calls(mockobj)
             [n_call, ~] = feval(mockobj.func, 'check_calls');
+            if isempty(n_call)
+                n_call = 0;
+            end
         end
         function arguments = get.arguments(mockobj)
             [~, arguments] = feval(mockobj.func, 'check_calls');
         end
     end
 end
-

--- a/external/mmat.m
+++ b/external/mmat.m
@@ -60,7 +60,8 @@ end
 nA = [size(A),ones(1,nD-nDA)]; nA = nA(dim); 
 nB = [size(B),ones(1,nD-nDB)]; nB = nB(dim);
 
-neededMem = (numel(A)*nB(2) + numel(B)*nA(1)) * 16;
+% Array is double float which is 8 bytes per element
+neededMem = (numel(A)*nB(2) + numel(B)*nA(1)) * 8;
 if sw_freemem < neededMem && isdefaultdim
     % Not enough memory to expand matrix to use bsxfun; use slow loop instead
     szA = size(A); if numel(szA) > 3, A = reshape(A, [szA(1:2) prod(szA(3:end))]); end
@@ -77,13 +78,14 @@ if sw_freemem < neededMem && isdefaultdim
         for ii = 1:size(A,3)
             C(:,:,ii) = A(:,:,ii) * B;
         end
-    else
+    elseif size(A, 3) == size(B, 3)
         output_shape = [szA(1) szB(2:end)];
-        if size(A, 3) ~= size(B, 3), error('Extra dimensions do not agree'); end
         C = zeros([szA(1) szB(2) size(A,3)]);
         for ii = 1:size(A,3)
             C(:,:,ii) = A(:,:,ii) * B(:,:,ii);
         end
+    else
+        error('Extra dimensions do not agree');
     end
     szC = size(C);
     if numel(szC) ~= numel(output_shape) || ~all(szC == output_shape)

--- a/external/mmat.m
+++ b/external/mmat.m
@@ -38,6 +38,7 @@ end
 if (nargin < 3)
     dim = [1 2];
 end
+isdefaultdim = all(dim == [1 2]);
 
 if numel(dim)~=2
     error('mmat:WrongInput','dim has to be a two element array!');
@@ -51,8 +52,45 @@ nDA = ndims(A);
 nDB = ndims(B);
 nD = max(nDA,nDB);
 
+if nD == 2 && isdefaultdim
+    C = A * B;
+    return
+end
+
 nA = [size(A),ones(1,nD-nDA)]; nA = nA(dim); 
 nB = [size(B),ones(1,nD-nDB)]; nB = nB(dim);
+
+neededMem = (numel(A)*nB(2) + numel(B)*nA(1)) * 16;
+if sw_freemem < neededMem && isdefaultdim
+    % Not enough memory to expand matrix to use bsxfun; use slow loop instead
+    szA = size(A); if numel(szA) > 3, A = reshape(A, [szA(1:2) prod(szA(3:end))]); end
+    szB = size(B); if numel(szB) > 3, B = reshape(B, [szB(1:2) prod(szB(3:end))]); end
+    if numel(szA) == 2 && numel(szB) > 2
+        output_shape = [szA(1) szB(2:end)];
+        C = zeros([szA(1) szB(2) size(B,3)]);
+        for ii = 1:size(B,3)
+            C(:,:,ii) = A * B(:,:,ii);
+        end
+    elseif numel(szA) > 2 && numel(szB) == 2
+        output_shape = [szA(1) szB(2) szA(3:end)];
+        C = zeros([szA(1) szB(2) size(A,3)]);
+        for ii = 1:size(A,3)
+            C(:,:,ii) = A(:,:,ii) * B;
+        end
+    else
+        output_shape = [szA(1) szB(2:end)];
+        if size(A, 3) ~= size(B, 3), error('Extra dimensions do not agree'); end
+        C = zeros([szA(1) szB(2) size(A,3)]);
+        for ii = 1:size(A,3)
+            C(:,:,ii) = A(:,:,ii) * B(:,:,ii);
+        end
+    end
+    szC = size(C);
+    if numel(szC) ~= numel(output_shape) || ~all(szC == output_shape)
+        C = reshape(C, output_shape);
+    end
+    return
+end
 
 % form A matrix
 % (nA1) x (nA2) x nB2

--- a/external/mmat.m
+++ b/external/mmat.m
@@ -60,8 +60,9 @@ end
 nA = [size(A),ones(1,nD-nDA)]; nA = nA(dim); 
 nB = [size(B),ones(1,nD-nDB)]; nB = nB(dim);
 
-% Array is double float which is 8 bytes per element
-neededMem = (numel(A)*nB(2) + numel(B)*nA(1)) * 8;
+% Array is double float which is 8 bytes per element, but this needs to be doubled
+% (16 bytes/element) as sum / bsxfun do not operate in-place and need a temp matrix
+neededMem = (numel(A)*nB(2) + numel(B)*nA(1)) * 16;
 if sw_freemem < neededMem && isdefaultdim
     % Not enough memory to expand matrix to use bsxfun; use slow loop instead
     szA = size(A); if numel(szA) > 3, A = reshape(A, [szA(1:2) prod(szA(3:end))]); end


### PR DESCRIPTION
In order to speed up the calculation of the matrix-matrix multiplication of a stack of matrices with just pure Matlab code, the computation the `mmat` function expands the matrices so that it can just use a single call to `bsxfun` to compute the element-wise multiplication in parallel followed by a single call to `sum`. 

However, this requires very large temporary arrays such that the system very rapidly runs out of memory - for example, multiplying an N×M by a stack M×N×L of L matrices requires two temporary arrays of size N×M×N×L matrices.

This PR changes the code so that if the memory requirements are too much, it instead computes the stacked matrix multiplication using loops which would be slow but at least the calculation will actually run.