### PR TITLE
Correct equations for q-range in sw_instrument

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -90,3 +90,5 @@ Bug Fixes
 - No longer require a magnetic structure be initialised with ``genmagstr``
   before using ``optmagstr``. If not intialised, a default ``nExt`` of
   ``[1 1 1]`` is used. This has also been clarified in the docstring.
+- ``sw_instrument`` now calculates the limits for thetaMax, before it was
+  using the continuation of the thetaMin line to high Q which is incorrect.

--- a/swfiles/sw_instrument.m
+++ b/swfiles/sw_instrument.m
@@ -57,6 +57,10 @@ function spectra = sw_instrument(spectra, varargin)
 % : Minimum scattering angle in \\deg, default value is 0. Can be only
 %   applied if one of the `ki`, `Ei`, `kf` or `Ef` parameters is defined.
 % 
+% `'thetaMax'`
+% : Maximum scattering angle in \\deg, default value is 135. Can be only
+%   applied if one of the `ki`, `Ei`, `kf` or `Ef` parameters is defined.
+%
 % `'plot'`
 % : If the resolution is read from file and plot option is
 %   true, the energy dependent resolution values together with the
@@ -273,7 +277,7 @@ switch FX
 end
 
 if FX > 0
-    k0 = param.k;
+    kfix = param.k;
     cosTMin = cosd(param.thetaMin);
     sinTMin = sind(param.thetaMin);
     cosTMax = cosd(param.thetaMax);
@@ -286,16 +290,16 @@ if FX > 0
                 % Ross Stewart, 9/2/23 - get proper trajectories based on thetamin *and* thetamax
                 Emax = Q*0;
                 Emin = Q*0;
-                ii = find(Q < k0);
-                Emax(ii) = (k0^2-(k0*cosTMin-sqrt(Q(ii).^2-k0^2*sinTMin^2)).^2) * sw_converter(1,'k','meV');
-                Emin(ii) = (k0^2-(k0*cosTMin+sqrt(Q(ii).^2-k0^2*sinTMin^2)).^2) * sw_converter(1,'k','meV');
-                ii = find(Q > k0);
-                Emax(ii) = (k0^2-(k0*cosTMax+sqrt(Q(ii).^2-k0^2*sinTMax^2)).^2) * sw_converter(1,'k','meV');
-                Emin(ii) = (k0^2-(k0*cosTMax-sqrt(Q(ii).^2-k0^2*sinTMax^2)).^2) * sw_converter(1,'k','meV');
+                ii = find(Q < kfix);
+                Emax(ii) = (kfix^2-(kfix*cosTMin-sqrt(Q(ii).^2-kfix^2*sinTMin^2)).^2) * sw_converter(1,'k','meV');
+                Emin(ii) = (kfix^2-(kfix*cosTMin+sqrt(Q(ii).^2-kfix^2*sinTMin^2)).^2) * sw_converter(1,'k','meV');
+                ii = find(Q > kfix);
+                Emax(ii) = (kfix^2-(kfix*cosTMax+sqrt(Q(ii).^2-kfix^2*sinTMax^2)).^2) * sw_converter(1,'k','meV');
+                Emin(ii) = (kfix^2-(kfix*cosTMax-sqrt(Q(ii).^2-kfix^2*sinTMax^2)).^2) * sw_converter(1,'k','meV');
             case 2
                 % fix kf
-                Emax = -(k0^2-(k0*cosT+sqrt(Q.^2-k0^2*sinT^2)).^2) * sw_converter(1,'k','meV');
-                Emin = -(k0^2-(k0*cosT-sqrt(Q.^2-k0^2*sinT^2)).^2) * sw_converter(1,'k','meV');
+                Emax = -(kfix^2-(kfix*cosT+sqrt(Q.^2-kfix^2*sinT^2)).^2) * sw_converter(1,'k','meV');
+                Emin = -(kfix^2-(kfix*cosT-sqrt(Q.^2-kfix^2*sinT^2)).^2) * sw_converter(1,'k','meV');
         end
 
         Emax(abs(imag(Emax))>0) = 0;
@@ -311,7 +315,7 @@ if FX > 0
         swConv(idx) = NaN;
         spectra.swConv{jj} = swConv;
     end
-    fprintf0(fid,'Energy transfer is limited to instrument, using %s=%5.3f A-1.\n',kstr,k0);
+    fprintf0(fid,'Energy transfer is limited to instrument, using %s=%5.3f A-1.\n',kstr,kfix);
 end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Original author: J. R. Stewart (ISIS).

This was contributed by a user who found that the equations used in `sw_instrument` for the kinematic limits were incorrect. That is the equations were correct mathematically but does not actually represent what happens in instruments. Rather they assumed that the detectors extended from `thetamin` to `180-thetamin`. Instead all spectrometers have a much more limited range of scattering angles defined by `thetamin` and a `thetamax` which is signifcantly less than 180 degrees (around 135 degrees maximum for the largest spectrometers; around 60 degrees for smaller / high resolution spectrometers).

This PR corrects this.

----

To Test:

Run an example powder script (e.g. [tutorial 1](https://www.spinw.org/tutorials/01tutorial#7), [5](https://www.spinw.org/tutorials/05tutorial#5), or [6](https://www.spinw.org/tutorials/06tutorial#5)), and run it through `sw_instrument` and check that the kinematic limits look like those in [Mantid PyChop](https://docs.mantidproject.org/nightly/interfaces/direct/PyChop.html)

