### PR TITLE
Fix sw_issymspec to recognise powder spectra

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -90,3 +90,5 @@ Bug Fixes
 - No longer require a magnetic structure be initialised with ``genmagstr``
   before using ``optmagstr``. If not intialised, a default ``nExt`` of
   ``[1 1 1]`` is used. This has also been clarified in the docstring.
+- Fix bug where powder spectra was not recognised in ``sw_plotspec``,
+  introduced by a previous update to provide more helpful error messages.

--- a/swfiles/private/sw_issymspec.m
+++ b/swfiles/private/sw_issymspec.m
@@ -25,6 +25,9 @@ end
 if ~isfield(spectra, 'ham')
     if isfield(spectra, 'omega')
         symobj = spectra.omega;
+    elseif size(spectra.hklA, 1) == 1  % Is a powder spectra
+        issym = false;
+        return
     else
         error('sw_issymspec:WrongInput', 'Invalid input spectra structure');
     end


### PR DESCRIPTION
Quick fix for issue #145 