### PR TITLE
Fourier sublattice bug

### DIFF
--- a/.github/workflows/build_pyspinw.yml
+++ b/.github/workflows/build_pyspinw.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Set up MATLAB
         uses: matlab-actions/setup-matlab@v1 # v1.1.0 required for Windows/MacOS support
         with:
-          release: latest
+          release: R2023a
       - name: Run python test
         run: |
           pip install scipy

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -94,3 +94,5 @@ Bug Fixes
   introduced by a previous update to provide more helpful error messages.
 - ``sw_instrument`` now calculates the limits for thetaMax, before it was
   using the continuation of the thetaMin line to high Q which is incorrect.
+- Fixes a parsing error in the ``spinw.fourier`` method if no sublat option
+  given.

--- a/swfiles/@spinw/fourier.m
+++ b/swfiles/@spinw/fourier.m
@@ -214,7 +214,10 @@ if ~isempty(param.sublat)
     atom2 = param.sublat(atom2);
     nMag  = max(param.sublat);
     nMag0 = numel(obj.matom.idx);
+    nsubl = nMag / nMag0;
     fprintf0(fid,'Remapping magnetic atoms into a new set of sublattices...\n');
+else
+    nsubl = 1;
 end
 
 % number of magnetic atoms in the magnetic supercell
@@ -289,7 +292,7 @@ end
 
 % save results in a struct
 % scale ft with the number of sublattices
-res.ft    = ft*(nMag/nMag0);
+res.ft    = ft * nsubl;
 res.hkl   = hkl;
 % Heisenberg output
 res.isiso = size(ft,1)==1;


### PR DESCRIPTION
Fixes a parsing error in the `spinw.fourier` method which occurs if the `sublat` option is not given.

As the function is rarely used and so is not tested this was not caught before.

It seems that originally there was no sublattice option, it was [introduced](https://github.com/SpinW/spinw/commit/da3ee73738efd79696973e27d82686a643c03bfd) in order to work with a new option in the developmental `scga` [method](https://github.com/SpinW/spinw/blob/ea5ea334a4056d74371b620954d2ff3adc0d27d3/dev/%40spinw/scga.m#L113) but the [original use](https://github.com/SpinW/spinw/commit/a18147d9d8144c498233749be6ad4832919c9eff) (e.g. in `scga3`) was not tested at the time (Aug 2017).