### PR TITLE
Update CI with new MATLAB version (2023b) and remove 2021a tests

### DIFF
--- a/.github/workflows/build_pyspinw.yml
+++ b/.github/workflows/build_pyspinw.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Build ctf
         run: |
           cd python
-          /Applications/MATLAB_${{ matrix.matlab_version }}.app/bin/matlab -nodisplay -r "build_ctf; exit"
+          matlab -nodisplay -r "build_ctf; exit"
       - name: Upload CTF results
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build_pyspinw.yml
+++ b/.github/workflows/build_pyspinw.yml
@@ -67,9 +67,9 @@ jobs:
           name: MEX
           path: ${{ github.workspace }}/external
       - name: Build ctf
-        run: |
-          cd python
-          matlab -nodisplay -r "build_ctf; exit"
+        uses: matlab-actions/run-command@v1
+        with:
+          command: "cd python; run build_ctf.m"
       - name: Upload CTF results
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build_pyspinw.yml
+++ b/.github/workflows/build_pyspinw.yml
@@ -67,9 +67,9 @@ jobs:
           name: MEX
           path: ${{ github.workspace }}/external
       - name: Build ctf
-        uses: matlab-actions/run-command@v1
-        with:
-          command: "cd python; run build_ctf.m"
+        run: |
+          cd python
+          /Applications/MATLAB_${{ matrix.matlab_version }}.app/bin/matlab -nodisplay -r "build_ctf; exit"
       - name: Upload CTF results
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build_pyspinw.yml
+++ b/.github/workflows/build_pyspinw.yml
@@ -54,7 +54,7 @@ jobs:
     needs: compile_mex
     strategy:
       matrix:
-        matlab_version: [R2021a, R2021b, R2022a, R2022b, R2023a]
+        matlab_version: [R2021b, R2022a, R2022b, R2023a, R2023b]
     runs-on: self-hosted
     steps:
       - name: Check out SpinW

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -16,7 +16,7 @@ jobs:
         matlab_version: [latest]
         include:
           - os: ubuntu-latest
-            matlab_version: R2020a
+            matlab_version: R2021b
           - os: macos-latest
             INSTALL_DEPS: brew install llvm libomp
       fail-fast: false


### PR DESCRIPTION
We believe the failure of the `build_ctf` on the ESS self-hosted runner (mac) is because MATLAB 2023b is not installed