### PR TITLE
Powder fitting

### DIFF
--- a/external/sw_qconv/sw_qconv.cpp
+++ b/external/sw_qconv/sw_qconv.cpp
@@ -1,0 +1,85 @@
+#include "mex.h"
+#include <stdexcept>
+#include <complex>
+#include <thread>
+#include <vector>
+
+template <typename T>
+void loop(T *swOut, const mwSize *d1, const double stdG, const double *Qconv, const T *swConv, size_t i0, size_t i1) {
+    for (size_t ii=i0; ii<i1; ii++) {
+        double sumfG = 0.0;
+        std::vector<double> fG(d1[1], 0.0);
+        for (size_t jj=0; jj<d1[1]; jj++) {
+            fG[jj] = exp(-pow((Qconv[jj] - Qconv[ii]) / stdG, 2) / 2);
+            sumfG += fG[jj];
+        }
+        for (size_t jj=0; jj<d1[1]; jj++) {
+            fG[jj] /= sumfG;
+            for (size_t kk=0; kk<d1[0]; kk++) {
+                swOut[kk+d1[0]*jj] += swConv[kk+d1[0]*ii] * fG[jj];
+            }
+        }
+    }
+}
+
+template <typename T>
+void do_calc(T *swOut, const mwSize *d1, const double stdG, const double *Qconv, const T *swConv, size_t nThread) {
+    if (d1[1] > 10*nThread) {
+        size_t nBlock = d1[1] / nThread;
+        size_t i0 = 0, i1 = nBlock;
+        std::vector<T*> swv(nThread);
+        std::vector<std::thread> threads;
+        for (size_t ii=0; ii<nThread; ii++) {
+            swv[ii] = new T[d1[0] * d1[1]];
+            threads.push_back(
+                std::thread(loop<T>, std::ref(swv[ii]), std::ref(d1), stdG, std::ref(Qconv), std::ref(swConv), i0, i1)
+            );
+            i0 = i1;
+            i1 += nBlock;
+            if (i1 > d1[1] || ii == (nThread - 2)) {
+                i1 = d1[1]; }
+        }
+        for (size_t ii=0; ii<nThread; ii++) {
+            if (threads[ii].joinable()) {
+                threads[ii].join(); }
+            for (size_t jj=0; jj<d1[0]; jj++) {
+                for (size_t kk=0; kk<d1[1]; kk++) {
+                    swOut[jj+kk*d1[0]] += swv[ii][jj+kk*d1[0]];
+                }
+            }
+            delete[](swv[ii]);
+        }
+    } else {
+        loop<T>(swOut, d1, stdG, Qconv, swConv, 0, d1[1]);
+    }
+}
+
+void mexFunction( int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[] )
+{
+    if (nrhs < 3) {
+        throw std::runtime_error("sw_qconv: Requires 3 arguments");
+    }
+    size_t nThreads = 8;
+    if (nrhs == 4) {
+        nThreads = (size_t)(*mxGetDoubles(prhs[3]));
+    }
+    if (mxIsComplex(prhs[1])) { throw std::runtime_error("Arg 2 is complex\n"); }
+    if (mxIsComplex(prhs[2])) { throw std::runtime_error("Arg 3 is complex\n"); }
+    const mwSize *d1 = mxGetDimensions(prhs[0]);
+    const mwSize *d2 = mxGetDimensions(prhs[1]);
+    if (d1[1] != d2[1]) { throw std::runtime_error("Arg 1 and 2 size mismatch\n"); }
+    if (mxGetNumberOfElements(prhs[2]) > 1) { throw std::runtime_error("Arg 3 should be scalar\n"); }
+    double *Qconv = mxGetDoubles(prhs[1]);
+    double stdG = *(mxGetDoubles(prhs[2]));
+    if (mxIsComplex(prhs[0])) {
+        std::complex<double> *swConv = reinterpret_cast<std::complex<double>*>(mxGetComplexDoubles(prhs[0]));
+        plhs[0] = mxCreateDoubleMatrix(d1[0], d1[1], mxCOMPLEX);
+        std::complex<double> *swOut = reinterpret_cast<std::complex<double>*>(mxGetComplexDoubles(plhs[0]));
+        do_calc(swOut, d1, stdG, Qconv, swConv, nThreads);
+    } else {
+        double *swConv = mxGetDoubles(prhs[0]);
+        plhs[0] = mxCreateDoubleMatrix(d1[0], d1[1], mxREAL);
+        double *swOut = mxGetDoubles(plhs[0]);
+        do_calc(swOut, d1, stdG, Qconv, swConv, nThreads);
+    }
+}

--- a/swfiles/@spinw/fitpow.m
+++ b/swfiles/@spinw/fitpow.m
@@ -1,0 +1,472 @@
+function fitsp = fitpow(obj, data, varargin)
+% fits experimental powder spin wave data
+% 
+% ### Syntax
+% 
+% `fitsp = fitpow(obj, data, Name, Value)`
+% 
+% ### Description
+% `fitsp = fitpow(obj, data, Name, Value)` takes a set of energy cuts of powder
+% spin wave spectrum and fits this.
+% 
+% ### Input Arguments
+% 
+% `obj`
+% : [spinw] object.
+% 
+% `data`
+% : input data cuts which may be an array of any of:
+%   * a Horace 1D sqw or d1d object
+%   * a struct with fields 'x', 'y', 'e', 'qmin', 'qmax'
+%   * a struct with fields 'IX', 'qmin', 'qmax'
+%   * a cell array {x y e qmin qmax}
+%   * a cell array {IX_dataset_1d qmin qmax}
+%   where x is a vector of energy transfer,
+%         y is a vector of intensity,
+%         e is a vector of uncertainties (errorbar)
+%         qmin is a scalar denoting the lower Q value of the cut
+%         qmax is a scalar denoting the upper Q value of the cut
+%         IX / IX_dataset_1d is a Horace IX_dataset_1D object
+%   Instead of the pair of scalars qmin, qmax, you specify a
+%   2-vector: [qmin qmax] under the key 'qrange', e.g.
+%   * a struct with fields 'x', 'y', 'e', 'qrange'
+%   * a cell array {x y e [qmin qmax]}
+%
+% ### Name-Value Pair Arguments
+% 
+% `'func'`
+% : Function to change the Hamiltonian in `obj`, it needs to have the
+%   following header:
+%   ```
+%   obj = @func(obj, x)
+%   ```
+% 
+% `'xmin'`
+% : Lower limit of the optimisation parameters, optional.
+% 
+% `'xmax'`
+% : Upper limit of the optimisation parameters, optional.
+% 
+% `'x0'`
+% : Starting value of the optimisation parameters. If empty
+%  or undefined, random values are used within the given limits.
+% 
+% `'optimizer'`
+% : String that determines the type of optimizer to use, possible values:
+%   * `'pso'`       Particle-swarm optimizer, see [ndbase.pso],
+%                   default.
+%   * `'simplex'`   Matlab built-in simplex optimizer, see [fminsearch](www.mathworks.ch/help/matlab/ref/fminsearch.html).
+% 
+% `'nRun'`
+% : Number of consecutive fitting runs, each result is saved in the
+%   output `fitsp.x` and `fitsp.R` arrays. If the Hamiltonian given by the
+%   random `x` parameters is incompatible with the ground state,
+%   those `x` values will be omitted and new random `x` values will be
+%   generated instead. Default value is 1.
+% 
+% `'nMax'`
+% : Maximum number of runs, including the ones that produce error
+%   (due to incompatible ground state). Default value is 1000.
+% 
+% `'hermit'`
+% : Method for matrix diagonalization, for details see [spinw.spinwave].
+% 
+% `'epsilon'`
+% : Small number that controls wether the magnetic structure is
+%   incommensurate or commensurate, default value is $10^{-5}$.
+% 
+% `'imagChk'`
+% : Checks that the imaginary part of the spin wave dispersion is
+%   smaller than the energy bin size. 
+%   If false, will not check
+%   If 'penalize' will apply a penalty to iterations that yield imaginary modes
+%   If true, will stop the fit if an iteration gives imaginary modes
+%   Default is `penalize`.
+% 
+% Parameters for visualizing the fit results:
+% 
+% `'plot'`
+% : If `true`, the measured dispersion is plotted together with the
+%   fit. Default is `true`.
+% 
+% `'iFact'`
+% : Factor of the plotted simulated spin wave intensity (red
+%   ellipsoids).
+% 
+% `'lShift'`
+% : Vertical shift of the `Q` point labels on the plot.
+% 
+% Optimizer options:
+% 
+% `'TolX'`
+% : Minimum change of` x` when convergence reached, default
+%   value is $10^{-4}$.
+% 
+% `'TolFun'`
+% : Minimum change of the R value when convergence reached,
+%   default value is $10^{-5}$.
+% 
+% `'MaxFunEvals'`
+% : Maximum number of function evaluations, default value is
+%   $10^7$.
+% 
+% `'MaxIter'`
+% : Maximum number of iterations for the [ndbse.pso] optimizer.
+%   Default value is 20.
+% 
+% ### Output Arguments
+% 
+% Output `fitsp` is struct type with the following fields:
+% * `obj`   Copy of the input `obj`, with the best fitted
+%           Hamiltonian parameters.
+% * `x`     Final values of the fitted parameters, dimensions are
+%           $[n_{run}\times n_{par}]$. The rows of `x` are sorted according 
+%           to increasing R values.
+% * `redX2` Reduced $\chi^2_\eta$ value, goodness of the fit stored in a column 
+%           vector with $n_{run}$ number of elements, sorted in increasing 
+%           order. $\chi^2_\eta$ is defined as:
+%
+%   $\begin{align}
+%                   \chi^2_\eta &= \frac{\chi^2}{\eta},\\
+%                   \eta        &= n-m+1,
+%   \end{align}$
+%   where \\eta is the degree of freedom, $n$ number of
+%   observations and $m$ is the number of fitted parameters.
+%
+% * `exitflag`  Exit flag of the `fminsearch` command.
+% * `output`    Output of the `fminsearch` command.
+% 
+% {{note As a rule of thumb when the variance of the measurement error is
+% known a priori, \\chi$^2_\eta$\\gg 1 indicates a poor model fit. A
+% \\chi$^2_\eta$\\gg 1 indicates that the fit has not fully captured the
+% data (or that the error variance has been underestimated). In principle,
+% a value of \\chi$^2_\eta$= 1 indicates that the extent of the match
+% between observations and estimates is in accord with the error variance.
+% A \\chi$^2_\eta$ < 1 indicates that the model is 'over-fitting' the data:
+% either the model is improperly fitting noise, or the error variance has
+% been overestimated.}}
+%
+% Any other option used by [spinw.spinwave] function are also accepted.
+% 
+% ### See Also
+% 
+% [spinw.spinwave] \| [spinw.matparser] \| [sw_egrid] \| [sw_neutron]
+%
+pref = swpref;
+tid0 = pref.tid;
+
+if nargin < 2
+    error('spinw:fitpow:MissingData','No input data cuts given')
+end
+
+inpForm.fname  = {'epsilon' 'xmin'   'xmax'  'x0'    'func' 'fibo' 'nRand'};
+inpForm.defval = {1e-5      []       []      []      []     true   100};
+inpForm.size   = {[1 1]     [1 -3]   [1 -4]  [1 -5]  [1 1]  [1 1]  [1 1]};
+inpForm.soft   = {true      true     true    true    false  false  false};
+
+inpForm.fname  = [inpForm.fname  {'formfact' 'formfactfun' 'conv_func' 'nQ'  'intensity_scale'}];
+inpForm.defval = [inpForm.defval {false      @sw_mff       @(s)s       10    0}];
+inpForm.size   = [inpForm.size   {[1 -2]     [1 1]         [1 1]       [1 1] [1 -9]}];
+inpForm.soft   = [inpForm.soft   {false      false         false       false true}];
+
+inpForm.fname  = [inpForm.fname  {'tolx' 'tolfun' 'maxfunevals' 'nRun' 'plot'}];
+inpForm.defval = [inpForm.defval {1e-4   1e-5     1e3           1      true}];
+inpForm.size   = [inpForm.size   {[1 1]  [1 1]    [1 1]         [1 1]  [1 1]}];
+inpForm.soft   = [inpForm.soft   {false  false    false         false  false}];
+
+inpForm.fname  = [inpForm.fname  {'nMax' 'hermit' 'iFact' 'lShift' 'optimizer'}];
+inpForm.defval = [inpForm.defval {1e3    true     1/30     0       'pso'      }];
+inpForm.size   = [inpForm.size   {[1 1]  [1 1]    [1 1]    [1 1]   [1 -7]     }];
+inpForm.soft   = [inpForm.soft   {false  false    false    false   false      }];
+
+inpForm.fname  = [inpForm.fname  {'maxiter' 'sw'  'optmem' 'tid' 'imagChk'}];
+inpForm.defval = [inpForm.defval {20        1     0        tid0  'penalize'}];
+inpForm.size   = [inpForm.size   {[1 1]  	[1 1] [1 1]    [1 1]  [1 -8]  }];
+inpForm.soft   = [inpForm.soft   {false  	false false    false  false   }];
+
+param = sw_readparam(inpForm, varargin{:});
+
+% number of parameters (length of x)
+nPar = max(max(length(param.xmin),length(param.xmax)),length(param.x0));
+nRun = param.nRun;
+
+% Parses the input data
+[lindat, data] = parse_cuts(data);
+
+% setup parameters for spinw.spinwave()
+param0      = param;
+%param0.plot = false;
+param0.tid  = 0;
+
+% Handle scale factor
+param0.fit_separate = false;
+param0.fit_together = false;
+param0.scale_factor = 1.0;
+if ischar(param.intensity_scale) || isstring(param.intensity_scale)
+    if strcmp(param.intensity_scale, 'fit_separate')
+        param0.fit_separate = true;
+    elseif strcmp(param.intensity_scale, 'fit_together')
+        param0.fit_together = true;
+    end
+elseif isfloat(param.intensity_scale)
+    param0.scale_factor = param.intensity_scale;
+end
+
+% Parses the imagChk parameter - we need to set it to true/false for spinw.spinwave()
+if strncmp(param.imagChk, 'penalize', 1)
+    param0.imagChk = true;
+    param0.penalize_imag = true;
+else
+    param0.imagChk = logical(param.imagChk(1));
+    param0.penalize_imag = false;
+end
+
+optfunname = sprintf('ndbase.%s', param.optimizer);
+assert(~isempty(which(optfunname)), 'spinw:fitpow:invalidoptimizer', 'Optimizer %s not recognised', param.optimizer);
+optimizer = str2func(optfunname);
+
+x     = zeros(nRun,nPar);
+redX2 = zeros(nRun,1);
+
+sw_timeit(0, 1, param.tid,'Fitting powder spin wave spectra');
+
+idx = 1;
+
+while idx <= nRun
+    if ~isempty(param.x0)
+        x0 = param.x0;
+    elseif isempty(param.xmax) && isempty(param.xmin)
+        x0 = rand(1,nPar);
+    elseif isempty(param.xmax)
+        x0 = param.xmin + rand(1,nPar);
+    elseif isempty(param.xmin)
+        x0 = param.xmax - rand(1,nPar);
+    else
+        x0 = rand(1,nPar).*(param.xmax-param.xmin)+param.xmin;
+    end
+
+    [x(idx,:),~, output(idx)] = optimizer(lindat, @(x,p)pow_fitfun(obj, lindat, data, param.func, p, param0), x0, ...
+        'lb', param.xmin, 'ub', param.xmax, ...
+        'TolX', param.tolx, 'TolFun', param.tolfun, 'MaxIter', param.maxiter);
+    redX2(idx) = output.redX2;
+    
+    idx = idx + 1;
+    sw_timeit(idx/nRun*100,0,param.tid);
+end
+
+sw_timeit(100,2,param.tid);
+
+% Sort results
+[redX2, sortIdx] = sort(redX2);
+x = x(sortIdx,:);
+
+% set the best fit to the spinw object
+param.func(obj,x(1,:));
+
+% Store all output in a struct variable.
+fitsp.obj      = copy(obj);
+fitsp.x        = x;
+fitsp.redX2    = redX2;
+%fitsp.exitflag = exitflag;
+fitsp.output   = output;
+
+end
+
+function out = horace1d_tostruct(dat)
+    assert(isa(dat, 'd1d') || isa(dat, 'sqw'), 'spinw:fitpow:invalidinput', 'Input must be a Horace 1D object, cell or struct');
+    if isa(dat, 'sqw')
+        assert(dat.dimensions == 1, 'spinw:fitpow:invalidinput', 'Input SQW object must be 1D');
+        dd = dat.data;
+    else
+        dd = dat;
+    end
+    assert(strcmp(dat.ulabel{1}, '|Q|'), 'spinw:fitpow:invalidinput', 'Input Horace object is not a powder cut');
+    out = struct('x', dd.p{1}, 'y', dd.s, 'e', dd.e, 'qmin', dd.iint(1,1), 'qmax', dd.iint(2,1));
+end
+
+function out = verify_cut_struct(dat)
+    if all(isfield(dat, {'x', 'y', 'e', 'qmin', 'qmax'}))
+        out = dat;
+    elseif all(isfield(dat, {'x', 'y', 'e', 'qrange'}))
+        out = struct('x', dat.x, 'y', dat.y, 'e', dat.e, 'qmin', dat.qrange(1), 'qmax', dat.qrange(2));
+    elseif all(isfield(dat, {'IX', 'qmin', 'qmax'}))
+        out = struct('x', dat.IX.x, 'y', dat.IX.signal, 'e', dat.IX.error, 'qmin', dat.qmin, 'qmax', dat.qmax);
+    elseif all(isfield(dat, {'IX', 'qrange'}))
+        out = struct('x', dat.IX.x, 'y', dat.IX.signal, 'e', dat.IX.error, 'qmin', dat.qrange(1), 'qmax', dat.qrange(2));
+    else
+        error('spinw:fitpow:invalidinput', 'Input structure must have fields (x,y,e) or (IX) and (qmin,qmax) or (qrange)');
+    end
+end
+
+function out = xyecell_tostruct(dat)
+    errmsg = 'Cell input should consist of IX_dataset objects or numeric arrays';
+    if numel(dat) > 3
+        assert(all(cellfun(@isnumeric, dat)), 'spinw:fitpow:invalidinput', errmsg);
+        xye = dat(1:3);
+        remd = dat(4:end);
+    elseif numel(dat) > 1
+        assert(isa(dat{1}, 'IX_dataset_1d'), 'spinw:fitpow:invalidinput', errmsg);
+        xye = {dat{1}.x, dat{1}.signal, dat{1}.error};
+        remd = dat(2:end);
+    end
+    if numel(remainder) == 2
+        out = struct('x', xye{1}, 'y', xye{2}, 'e', xye{3}, 'qmin', remd{1}, 'qmax', remd{2});
+    else
+        out = struct('x', xye{1}, 'y', xye{2}, 'e', xye{3}, 'qmin', remd{1}(1), 'qmax', remd{1}(2));
+    end
+end
+
+function [lindat, outstruct] = parse_cuts(input)
+    %outstruct = struct();
+    if iscell(input)
+        for ii = 1:numel(input)
+            if isstruct(input{ii})
+                outstruct(ii) = verify_cut_struct(input{ii});
+            elseif iscell(input{ii})
+                outstruct(ii) = xyecell_tostruct(input{ii});
+            else
+                outstruct(ii) = horace1d_tostruct(input{ii});
+            end
+        end
+    elseif isstruct(input)
+        for ii = 1:numel(input)
+            outstruct(ii) = verify_cut_struct(input(ii));
+        end
+    else
+        for ii = 1:numel(input)
+            outstruct(ii) = horace1d_tostruct(input(ii));
+        end
+    end
+    for ii = 1:numel(outstruct)
+        xx = outstruct(ii).x(:).';
+        df = diff(xx) ./ 2;
+        outstruct(ii).evect = [xx(1)-df(1), xx(1:end-1) + df, xx(end) + df(end)];
+    end
+    lindat = linearise_data(outstruct);
+end
+
+function lindat = linearise_data(outstruct)
+    % Linearise the data
+    [x, y, e] = deal([], [], []);
+    is_same_e = true;
+    for ii = 1:numel(outstruct)
+        x = [x; ii+([1:numel(outstruct(ii).y)]/1e9)];
+        y = [y; outstruct(ii).y];
+        e = [e; outstruct(ii).e];
+        if ii == 1
+            evec = outstruct(ii).x;
+        else
+            if ~is_same_e && (numel(evec) ~= numel(outstruct(ii).x) ... 
+                             || sum(abs(evec(:) - outstruc(ii).x(:))) > 1e-5)
+               is_same_e = false;
+            end
+        end
+    end
+    lindat = struct('x', x, 'y', y, 'e', e, 'is_same_e', is_same_e);
+end
+
+
+function yCalc = pow_fitfun(obj, lindat, data, parfunc, x, param)
+% calculates the powder spin wave spectrum to directly compare to data
+%
+% yCalc = SW_FITFUN(obj, data, swfunc, x, param)
+%
+% swobj         spinw object
+% data          Structure contains the experimental data
+% swfunc        Function to change the Hamiltonian in obj, of the form:
+%                   obj = swfunc(obj,x);
+% x             Actual parameter values.
+% param         Parameters for the spinwave function.
+
+persistent swp hf lines;
+if isempty(swp)
+    swp = swpref;
+end
+fid0 = swp.fid;
+swp.fid = 0;
+cleanupObj = onCleanup(@()swpref.setpref('fid', fid0));
+
+parfunc(obj,x);
+
+if param.plot
+    if isempty(hf) || ~isvalid(hf)
+        hf = findobj('Tag', 'fitpow_plot');
+    end
+    if isempty(hf) || ~isvalid(hf)
+        hf = figure('Tag', 'fitpow_plot');
+        for ii = 1:numel(data)
+            subplot(1, numel(data), ii); hold all;
+            errorbar(data(ii).x, data(ii).y, data(ii).e, '.k');
+        end
+        lines = [];
+    end
+    set(0, 'CurrentFigure', hf);
+end
+
+fitstruc = data;
+sf = param.scale_factor;
+nD = numel(data);
+nY = 0;
+
+if lindat.is_same_e
+    nY = nD * numel(data(1).x);
+    qq = zeros(nD * param.nQ);
+    for ii = 1:nD
+        i0 = (ii - 1) * param.nQ + 1;
+        qq(i0:(i0 + param.nQ - 1)) = linspace(data(ii).qmin, data(ii).qmax, param.nQ);
+    end
+    spec = obj.powspec(qq, 'Evect', data(1).evect, 'nRand', param.nRand, 'fibo', param.fibo, ...
+        'hermit', param.hermit, 'formfact', param.formfact, 'formfactfun', param.formfactfun, ...
+        'imagChk', param.imagChk);
+    spec = param.conv_func(spec);
+    for ii = 1:nD
+        i0 = (ii - 1) * param.nQ + 1;
+        fitstruc(ii).y = sum(spec.swConv(:, i0:(i0 + param.nQ - 1)), 2);
+    end
+else
+    for ii = 1:nD
+        qq = linspace(data(ii).qmin, data(ii).qmax, param.nQ);
+        spec = obj.powspec(qq, 'Evect', data(ii).evect, 'nRand', param.nRand, 'fibo', param.fibo, ...
+            'hermit', param.hermit, 'formfact', param.formfact, 'formfactfun', param.formfactfun, ...
+            'imagChk', param.imagChk);
+        spec = param.conv_func(spec);
+        fitstruc(ii).y = sum(spec.swConv, 2);
+        nY = nY + numel(fitstruc(ii).y);
+    end
+end
+
+yCalc = zeros(nY, 1);
+i0 = 1;
+for ii = 1:numel(data)
+    if param.fit_separate
+        sf = 1.0;
+        ssf = fminsearch(@(x)sum(abs(data(ii).y(:) - x*fitstruc(ii).y(:)), 'omitnan'), max(data(ii).y) / max(fitstruc(ii).y));
+        if ssf < 1e5
+            fitstruc(ii).y = ssf * fitstruc(ii).y;
+        end
+    end
+    i1 = i0 + numel(fitstruc(ii).y) - 1;
+    yCalc(i0:i1) = fitstruc(ii).y;
+    i0 = i1 + 1;
+end
+
+if param.fit_together
+    sf = fminsearch(@(x)sum(abs(lindat.y(:) - x*yCalc(:)), 'omitnan'), max(l0.y) / max(yCalc));
+end
+
+if sf ~= 1.0
+    yCalc = sf * yCalc;
+end
+
+if param.plot
+    for ii = 1:numel(data)
+        subplot(1, numel(data), ii);
+        try %#ok<TRYNC>
+            delete(lines(ii));
+        end
+        lines(ii) = plot(fitstruc(ii).x, sf * fitstruc(ii).y, '-r');
+    end
+    drawnow;
+end
+
+end

--- a/swfiles/@spinw/fitpow.m
+++ b/swfiles/@spinw/fitpow.m
@@ -1,19 +1,19 @@
 function fitsp = fitpow(obj, data, varargin)
 % fits experimental powder spin wave data
-% 
+%
 % ### Syntax
-% 
+%
 % `fitsp = fitpow(obj, data, Name, Value)`
-% 
+%
 % ### Description
 % `fitsp = fitpow(obj, data, Name, Value)` takes a set of energy cuts of powder
 % spin wave spectrum and fits this.
-% 
+%
 % ### Input Arguments
-% 
+%
 % `obj`
 % : [spinw] object.
-% 
+%
 % `data`
 % : input data cuts which may be an array of any of:
 %   * a Horace 1D sqw or d1d object
@@ -33,97 +33,118 @@ function fitsp = fitpow(obj, data, varargin)
 %   * a cell array {x y e [qmin qmax]}
 %
 % ### Name-Value Pair Arguments
-% 
+%
 % `'func'`
 % : Function to change the Hamiltonian in `obj`, it needs to have the
 %   following header:
 %   ```
 %   obj = @func(obj, x)
 %   ```
-% 
+%
 % `'xmin'`
 % : Lower limit of the optimisation parameters, optional.
-% 
+%
 % `'xmax'`
 % : Upper limit of the optimisation parameters, optional.
-% 
+%
 % `'x0'`
 % : Starting value of the optimisation parameters. If empty
 %  or undefined, random values are used within the given limits.
-% 
+%
 % `'optimizer'`
 % : String that determines the type of optimizer to use, possible values:
+%   * `'lm3'`       (Default) Levenberg-Marquardt as implemented in Horace, see [ndbase.lm3],
 %   * `'pso'`       Particle-swarm optimizer, see [ndbase.pso],
-%                   default.
 %   * `'simplex'`   Matlab built-in simplex optimizer, see [fminsearch](www.mathworks.ch/help/matlab/ref/fminsearch.html).
-% 
+%
 % `'nRun'`
 % : Number of consecutive fitting runs, each result is saved in the
 %   output `fitsp.x` and `fitsp.R` arrays. If the Hamiltonian given by the
 %   random `x` parameters is incompatible with the ground state,
 %   those `x` values will be omitted and new random `x` values will be
 %   generated instead. Default value is 1.
-% 
+%
 % `'nMax'`
 % : Maximum number of runs, including the ones that produce error
 %   (due to incompatible ground state). Default value is 1000.
-% 
+%
+% `'nQ'`
+% : Number of |Q| points to use for each cut to simulate cut thickness
+%   Default is 10.
+%
 % `'hermit'`
 % : Method for matrix diagonalization, for details see [spinw.spinwave].
-% 
-% `'epsilon'`
-% : Small number that controls wether the magnetic structure is
-%   incommensurate or commensurate, default value is $10^{-5}$.
-% 
+%
+% `'formfact'`
+% : Whether to include the form factor in the calculation (Default: true)
+%
+% `'formfactfun'`
+% : The function used to calculate the form factor (Default: sw_mff)
+%
+% `'conv_func'`
+% : The convolution function used to broaden the data in |Q| and E.
+%   Default: no convolution is applied.
+%
 % `'imagChk'`
 % : Checks that the imaginary part of the spin wave dispersion is
-%   smaller than the energy bin size. 
+%   smaller than the energy bin size.
 %   If false, will not check
 %   If 'penalize' will apply a penalty to iterations that yield imaginary modes
 %   If true, will stop the fit if an iteration gives imaginary modes
 %   Default is `penalize`.
-% 
-% Parameters for visualizing the fit results:
-% 
+%
+% `'intensity_scale'`
+% : The scale factor for the intensity. Use a negative number for a fixed scale factor,
+%   positive for it to be fitted from the given initial value,
+%   and 0 for it to be fitted with an initial value guessed from the data.
+%   Default: -1  (fixed, no scale factor applied).
+%
+% `'background'`
+% : The type of background to use. Either 'none', 'flat', 'linear', 'quadratic'
+%
+% `'background_par'`
+% : The initial background parameters as a vector from highest order.
+%   E.g. if using ('background', 'quadratic'), then ('background_par', [a, b, c])
+%   where the background used will be a*x.^2 + b*x + c.
+%   Default: []  (empty vector - initial parameters will be guessed from data).
+%
+% Parameters for monitoring the fitting:
+%
 % `'plot'`
-% : If `true`, the measured dispersion is plotted together with the
-%   fit. Default is `true`.
-% 
-% `'iFact'`
-% : Factor of the plotted simulated spin wave intensity (red
-%   ellipsoids).
-% 
-% `'lShift'`
-% : Vertical shift of the `Q` point labels on the plot.
-% 
+% : If `true`, the data and fits are plotted as the fitting process progresses.
+%   Default is `true`.
+%
+% `'verbose'`
+% : Whether to print information as the fit progresses
+%   Default is `true`.
+%
 % Optimizer options:
-% 
+%
 % `'TolX'`
 % : Minimum change of` x` when convergence reached, default
 %   value is $10^{-4}$.
-% 
+%
 % `'TolFun'`
 % : Minimum change of the R value when convergence reached,
 %   default value is $10^{-5}$.
-% 
-% `'MaxFunEvals'`
-% : Maximum number of function evaluations, default value is
-%   $10^7$.
-% 
-% `'MaxIter'`
+%
+% `'maxfunevals'`
+% : Maximum number of function evaluations, default value is $10^3$.
+%
+% `'maxiter'`
 % : Maximum number of iterations for the [ndbse.pso] optimizer.
 %   Default value is 20.
-% 
+%
 % ### Output Arguments
-% 
+%
 % Output `fitsp` is struct type with the following fields:
 % * `obj`   Copy of the input `obj`, with the best fitted
 %           Hamiltonian parameters.
 % * `x`     Final values of the fitted parameters, dimensions are
-%           $[n_{run}\times n_{par}]$. The rows of `x` are sorted according 
+%           $[n_{run}\times n_{par}]$. The rows of `x` are sorted according
 %           to increasing R values.
-% * `redX2` Reduced $\chi^2_\eta$ value, goodness of the fit stored in a column 
-%           vector with $n_{run}$ number of elements, sorted in increasing 
+% * `redX2` Reduced $\chi^2_\eta$ value, goodness of the fit stored in a column
+%           vector with $n_{run}$ number of elements, sorted in increasing
 %           order. $\chi^2_\eta$ is defined as:
 %
 %   $\begin{align}
@@ -135,7 +156,7 @@ function fitsp = fitpow(obj, data, varargin)
 %
 % * `exitflag`  Exit flag of the `fminsearch` command.
 % * `output`    Output of the `fminsearch` command.
-% 
+%
 % {{note As a rule of thumb when the variance of the measurement error is
 % known a priori, \\chi$^2_\eta$\\gg 1 indicates a poor model fit. A
 % \\chi$^2_\eta$\\gg 1 indicates that the fit has not fully captured the
@@ -147,11 +168,12 @@ function fitsp = fitpow(obj, data, varargin)
 % been overestimated.}}
 %
 % Any other option used by [spinw.spinwave] function are also accepted.
-% 
+%
 % ### See Also
-% 
+%
 % [spinw.spinwave] \| [spinw.matparser] \| [sw_egrid] \| [sw_neutron]
 %
+
 pref = swpref;
 tid0 = pref.tid;
 
@@ -159,25 +181,30 @@ if nargin < 2
     error('spinw:fitpow:MissingData','No input data cuts given')
 end
 
-inpForm.fname  = {'epsilon' 'xmin'   'xmax'  'x0'    'func' 'fibo' 'nRand'};
-inpForm.defval = {1e-5      []       []      []      []     true   100};
-inpForm.size   = {[1 1]     [1 -3]   [1 -4]  [1 -5]  [1 1]  [1 1]  [1 1]};
-inpForm.soft   = {true      true     true    true    false  false  false};
+inpForm.fname  = {'xmin'   'xmax'  'x0'    'func' 'fibo' 'nRand' 'verbose'};
+inpForm.defval = {[]       []      []      []     true   100     true};
+inpForm.size   = {[1 -3]   [1 -4]  [1 -5]  [1 1]  [1 1]  [1 1]   [1 1]};
+inpForm.soft   = {true     true    true    false  false  false   false};
 
-inpForm.fname  = [inpForm.fname  {'formfact' 'formfactfun' 'conv_func' 'nQ'  'intensity_scale'}];
-inpForm.defval = [inpForm.defval {false      @sw_mff       @(s)s       10    0}];
-inpForm.size   = [inpForm.size   {[1 -2]     [1 1]         [1 1]       [1 1] [1 -9]}];
-inpForm.soft   = [inpForm.soft   {false      false         false       false true}];
+inpForm.fname  = [inpForm.fname  {'formfact' 'formfactfun' 'conv_func' 'nQ'}];
+inpForm.defval = [inpForm.defval {true       @sw_mff       @(s)s       10}];
+inpForm.size   = [inpForm.size   {[1 -2]     [1 1]         [1 1]       [1 1]}];
+inpForm.soft   = [inpForm.soft   {false      false         false       false}];
+
+inpForm.fname  = [inpForm.fname  {'intensity_scale' 'background' 'background_par'}];
+inpForm.defval = [inpForm.defval {-1                'linear'     []}];
+inpForm.size   = [inpForm.size   {[1 1]             [1 -9]       [1 -10]}];
+inpForm.soft   = [inpForm.soft   {false             false        true}];
 
 inpForm.fname  = [inpForm.fname  {'tolx' 'tolfun' 'maxfunevals' 'nRun' 'plot'}];
 inpForm.defval = [inpForm.defval {1e-4   1e-5     1e3           1      true}];
 inpForm.size   = [inpForm.size   {[1 1]  [1 1]    [1 1]         [1 1]  [1 1]}];
 inpForm.soft   = [inpForm.soft   {false  false    false         false  false}];
 
-inpForm.fname  = [inpForm.fname  {'nMax' 'hermit' 'iFact' 'lShift' 'optimizer'}];
-inpForm.defval = [inpForm.defval {1e3    true     1/30     0       'pso'      }];
-inpForm.size   = [inpForm.size   {[1 1]  [1 1]    [1 1]    [1 1]   [1 -7]     }];
-inpForm.soft   = [inpForm.soft   {false  false    false    false   false      }];
+inpForm.fname  = [inpForm.fname  {'nMax' 'hermit' 'optimizer'}];
+inpForm.defval = [inpForm.defval {1e3    true     'lm3'      }];
+inpForm.size   = [inpForm.size   {[1 1]  [1 1]    [1 -7]     }];
+inpForm.soft   = [inpForm.soft   {false  false    false      }];
 
 inpForm.fname  = [inpForm.fname  {'maxiter' 'sw'  'optmem' 'tid' 'imagChk'}];
 inpForm.defval = [inpForm.defval {20        1     0        tid0  'penalize'}];
@@ -198,20 +225,6 @@ param0      = param;
 %param0.plot = false;
 param0.tid  = 0;
 
-% Handle scale factor
-param0.fit_separate = false;
-param0.fit_together = false;
-param0.scale_factor = 1.0;
-if ischar(param.intensity_scale) || isstring(param.intensity_scale)
-    if strcmp(param.intensity_scale, 'fit_separate')
-        param0.fit_separate = true;
-    elseif strcmp(param.intensity_scale, 'fit_together')
-        param0.fit_together = true;
-    end
-elseif isfloat(param.intensity_scale)
-    param0.scale_factor = param.intensity_scale;
-end
-
 % Parses the imagChk parameter - we need to set it to true/false for spinw.spinwave()
 if strncmp(param.imagChk, 'penalize', 1)
     param0.imagChk = true;
@@ -225,7 +238,7 @@ optfunname = sprintf('ndbase.%s', param.optimizer);
 assert(~isempty(which(optfunname)), 'spinw:fitpow:invalidoptimizer', 'Optimizer %s not recognised', param.optimizer);
 optimizer = str2func(optfunname);
 
-x     = zeros(nRun,nPar);
+%x     = zeros(nRun,nPar);
 redX2 = zeros(nRun,1);
 
 sw_timeit(0, 1, param.tid,'Fitting powder spin wave spectra');
@@ -244,12 +257,77 @@ while idx <= nRun
     else
         x0 = rand(1,nPar).*(param.xmax-param.xmin)+param.xmin;
     end
+    xmin = param.xmin;
+    xmax = param.xmax;
 
+    % Handle scale factor
+    if param.intensity_scale < 0
+        param0.fit_scale = false;
+    else
+        if param.intensity_scale == 0
+            sf = guess_intensity(obj, data, param0);
+        else
+            sf = param.intensity_scale;
+        end
+        param0.fit_scale = true;
+        x0 = [x0 sf];
+        if ~isempty(xmin)
+            xmin = [xmin 0];
+        end
+        if ~isempty(xmax)
+            xmax = [xmax 10*sf];
+        end
+    end
+
+    % Handle background
+    param0.bkgfun = [];
+    if ~strcmp(param.background, 'none')
+        xb = param.background_par;
+        if strcmp(param.background, 'flat')
+            param0.bkgfun = @(x, p) ones(numel(x),1)*p;
+            if isempty(xb)
+                xb = min(lindat.y);
+            end
+            xnx = 0;
+            xmx = max(lindat.y) / 2;
+        elseif strcmp(param.background, 'linear')
+            param0.bkgfun = @(x, p) x*p(1) + p(2);
+            if isempty(xb)
+                xb = guess_bkg(data, 'linear');
+            end
+            xnx = [-abs(xb(1))*2, 0];
+            xmx = [abs(xb(1))*2, max(lindat.y)/2];
+        elseif strcmp(param.background, 'quadratic')
+            param0.bkgfun = @(x, p) x.^2*p(1) + x*p(2) + p(3);
+            if isempty(xb)
+                xb = guess_bkg(data, 'quadratic');
+            end
+            xnx = [-abs(xb(1:2))*2, 0];
+            xmx = [abs(xb(1:2))*2, max(lindat.y)/2];
+        else
+            error('spinw:fitpow:unknownbackground', 'Background type %s not supported', param.background);
+        end
+        xb(isnan(xb)) = 0;
+        x0 = [x0 xb]; %#ok<*AGROW>
+        param0.nbkgpar = numel(xb);
+        if ~isempty(xmin)
+            xmin = [xmin xnx];
+        end
+        if ~isempty(xmax)
+            xmax = [xmax xmx];
+        end
+    end
+
+    % Only cache powder calcs for gradient methods
+    if strncmp(param.optimizer, 'lm', 2)
+        pow_fitfun('clear_cache');
+    else
+        pow_fitfun('no_cache');
+    end
     [x(idx,:),~, output(idx)] = optimizer(lindat, @(x,p)pow_fitfun(obj, lindat, data, param.func, p, param0), x0, ...
-        'lb', param.xmin, 'ub', param.xmax, ...
-        'TolX', param.tolx, 'TolFun', param.tolfun, 'MaxIter', param.maxiter);
+        'lb', xmin, 'ub', xmax, 'TolX', param.tolx, 'TolFun', param.tolfun, 'MaxIter', param.maxiter);
     redX2(idx) = output.redX2;
-    
+
     idx = idx + 1;
     sw_timeit(idx/nRun*100,0,param.tid);
 end
@@ -261,7 +339,7 @@ sw_timeit(100,2,param.tid);
 x = x(sortIdx,:);
 
 % set the best fit to the spinw object
-param.func(obj,x(1,:));
+param.func(obj,x(1,1:nPar));
 
 % Store all output in a struct variable.
 fitsp.obj      = copy(obj);
@@ -281,7 +359,7 @@ function out = horace1d_tostruct(dat)
         dd = dat;
     end
     assert(strcmp(dat.ulabel{1}, '|Q|'), 'spinw:fitpow:invalidinput', 'Input Horace object is not a powder cut');
-    out = struct('x', dd.p{1}, 'y', dd.s, 'e', dd.e, 'qmin', dd.iint(1,1), 'qmax', dd.iint(2,1));
+    out = struct('x', (dd.p{1}(1:end-1) + dd.p{1}(2:end))/2, 'y', dd.s, 'e', dd.e, 'qmin', dd.iint(1,1), 'qmax', dd.iint(2,1));
 end
 
 function out = verify_cut_struct(dat)
@@ -350,21 +428,62 @@ function lindat = linearise_data(outstruct)
     [x, y, e] = deal([], [], []);
     is_same_e = true;
     for ii = 1:numel(outstruct)
-        x = [x; ii+([1:numel(outstruct(ii).y)]/1e9)];
-        y = [y; outstruct(ii).y];
-        e = [e; outstruct(ii).e];
+        x = [x; ii+([1:numel(outstruct(ii).y)].'/1e9)]; %#ok<NBRAK>
+        y = [y; outstruct(ii).y(:)];
+        e = [e; outstruct(ii).e(:)];
         if ii == 1
             evec = outstruct(ii).x;
         else
-            if ~is_same_e && (numel(evec) ~= numel(outstruct(ii).x) ... 
+            if ~is_same_e && (numel(evec) ~= numel(outstruct(ii).x) ...
                              || sum(abs(evec(:) - outstruc(ii).x(:))) > 1e-5)
                is_same_e = false;
             end
         end
     end
+    e(isnan(y)) = 1;
+    y(isnan(y)) = 0;
+    e(e==0) = 1;
     lindat = struct('x', x, 'y', y, 'e', e, 'is_same_e', is_same_e);
 end
 
+function out = is_same_data(d0, data)
+    out = numel(d0) == numel(data) && numel(d0(1).x) == numel(data(1).x) && ...
+        all(d0(1).x(:) == data(1).x(:));
+end
+
+function out = guess_bkg(data, bktype)
+    xx = []; yy = [];
+    for ii = 1:numel(data)
+        xx = [xx; data(ii).x(:)];
+        yy = [yy; data(ii).y(:)];
+    end
+    my = min(yy);
+    idx = find(yy < (max(yy)-my)/20+my);
+    [xx, isr] = sort(xx(idx));
+    yy = yy(idx(isr));
+    p2 = yy(end) / xx(end).^2;
+    p1 = (yy(end) - yy(1)) / (xx(end) - xx(1));
+    p0 = min(yy);
+    if strcmp(bktype, 'linear')
+        out = fminsearch(@(p) sum(abs(yy - (p(1)*xx + p(2)))), [p1 p0]);
+    elseif strcmp(bktype, 'quadratic')
+        out = fminsearch(@(p) sum(abs(yy - (p(1)*xx.^2 + p(2)*xx + p(3)))), [p2 p1 p0]);
+    end
+end
+
+function out = guess_intscale(swobj, data, param)
+    sfs = zeros(numel(data), 1);
+    for ii = 1:numel(data)
+        qq = linspace(data(ii).qmin, data(ii).qmax, param.nQ);
+        spec = swobj.powspec(qq, 'Evect', data(ii).evect, 'nRand', 100, 'fibo', param.fibo, ...
+            'hermit', param.hermit, 'formfact', param.formfact, 'formfactfun', param.formfactfun, ...
+            'imagChk', param.imagChk);
+        spec = param.conv_func(spec);
+        yy = sum(spec.swConv, 2);
+        sfs(ii) = max(data(ii).y) / max(yy);
+    end
+    out = mean(sfs);
+end
 
 function yCalc = pow_fitfun(obj, lindat, data, parfunc, x, param)
 % calculates the powder spin wave spectrum to directly compare to data
@@ -378,7 +497,21 @@ function yCalc = pow_fitfun(obj, lindat, data, parfunc, x, param)
 % x             Actual parameter values.
 % param         Parameters for the spinwave function.
 
-persistent swp hf lines;
+persistent swp hf lines d0 useCache cache nCache iCache nEval;
+
+if ischar(obj)
+    if strcmp(obj, 'clear_cache')
+        cache = [];
+        nCache = [];
+        iCache = 1;
+        useCache = true;
+    elseif strcmp(obj, 'no_cache')
+        useCache = false;
+    end
+    nEval = 0;
+    return;
+end
+
 if isempty(swp)
     swp = swpref;
 end
@@ -386,87 +519,150 @@ fid0 = swp.fid;
 swp.fid = 0;
 cleanupObj = onCleanup(@()swpref.setpref('fid', fid0));
 
-parfunc(obj,x);
+% Strip out background and intensity parameters before feeding the SpinW model
+x_rem = x;
+if param.verbose
+    fprintf('Evaluation #%i with parameters:', nEval); fprintf('%f ', x_rem);
+    nEval = nEval + 1;
+end
+sf = 1.0;
+if param.intensity_scale < 0
+    sf = abs(param.intensity_scale);
+else
+    if ~isempty(param.bkgfun)
+        bkgpar = x_rem((end-param.nbkgpar+1):end);
+        x_rem = x_rem(1:(end-param.nbkgpar));
+    end
+    if param.fit_scale
+        sf = x_rem(end);
+        x_rem = x_rem(1:end-1);
+    end
+end
+
+% Modify the SpinW model with new parameters
+parfunc(obj, x_rem);
+
+% Other setup
+fitstruc = data;
+nD = numel(data);
+nY = 0;
 
 if param.plot
-    if isempty(hf) || ~isvalid(hf)
+    if isempty(hf) || ~isvalid(hf) && (isempty(d0) || is_same_data(d0, data))
         hf = findobj('Tag', 'fitpow_plot');
     end
     if isempty(hf) || ~isvalid(hf)
         hf = figure('Tag', 'fitpow_plot');
-        for ii = 1:numel(data)
-            subplot(1, numel(data), ii); hold all;
+        nR = ceil(nD / 4);
+        for ii = 1:nD
+            subplot(nR, ceil(nD / nR), ii); hold all;
             errorbar(data(ii).x, data(ii).y, data(ii).e, '.k');
+            title(sprintf('%4.2f < |Q| < %4.2f', data(ii).qmin, data(ii).qmax));
+            box on;
         end
         lines = [];
+        d0 = data;
     end
     set(0, 'CurrentFigure', hf);
 end
 
-fitstruc = data;
-sf = param.scale_factor;
-nD = numel(data);
-nY = 0;
-
-if lindat.is_same_e
-    nY = nD * numel(data(1).x);
-    qq = zeros(nD * param.nQ);
-    for ii = 1:nD
-        i0 = (ii - 1) * param.nQ + 1;
-        qq(i0:(i0 + param.nQ - 1)) = linspace(data(ii).qmin, data(ii).qmax, param.nQ);
+not_cached = true;
+if ~isempty(cache) && useCache
+    for ii = 1:numel(cache)
+        if x_rem == cache{ii}{1}
+            not_cached = false;
+            fitstruc = cache{ii}{2};
+            break
+        end
     end
-    spec = obj.powspec(qq, 'Evect', data(1).evect, 'nRand', param.nRand, 'fibo', param.fibo, ...
-        'hermit', param.hermit, 'formfact', param.formfact, 'formfactfun', param.formfactfun, ...
-        'imagChk', param.imagChk);
-    spec = param.conv_func(spec);
-    for ii = 1:nD
-        i0 = (ii - 1) * param.nQ + 1;
-        fitstruc(ii).y = sum(spec.swConv(:, i0:(i0 + param.nQ - 1)), 2);
-    end
-else
-    for ii = 1:nD
-        qq = linspace(data(ii).qmin, data(ii).qmax, param.nQ);
-        spec = obj.powspec(qq, 'Evect', data(ii).evect, 'nRand', param.nRand, 'fibo', param.fibo, ...
+end
+if not_cached
+    if lindat.is_same_e
+        nY = nD * numel(data(1).x);
+        qq = zeros(nD * param.nQ);
+        for ii = 1:nD
+            i0 = (ii - 1) * param.nQ + 1;
+            qq(i0:(i0 + param.nQ - 1)) = linspace(data(ii).qmin, data(ii).qmax, param.nQ);
+        end
+        spec = obj.powspec(qq, 'Evect', data(1).evect, 'nRand', param.nRand, 'fibo', param.fibo, ...
             'hermit', param.hermit, 'formfact', param.formfact, 'formfactfun', param.formfactfun, ...
             'imagChk', param.imagChk);
         spec = param.conv_func(spec);
-        fitstruc(ii).y = sum(spec.swConv, 2);
-        nY = nY + numel(fitstruc(ii).y);
+        for ii = 1:nD
+            i0 = (ii - 1) * param.nQ + 1;
+            fitstruc(ii).y = sum(spec.swConv(:, i0:(i0 + param.nQ - 1)), 2);
+        end
+    else
+        for ii = 1:nD
+            qq = linspace(data(ii).qmin, data(ii).qmax, param.nQ);
+            spec = obj.powspec(qq, 'Evect', data(ii).evect, 'nRand', param.nRand, 'fibo', param.fibo, ...
+                'hermit', param.hermit, 'formfact', param.formfact, 'formfactfun', param.formfactfun, ...
+                'imagChk', param.imagChk);
+            spec = param.conv_func(spec);
+            fitstruc(ii).y = sum(spec.swConv, 2);
+            nY = nY + numel(fitstruc(ii).y);
+        end
+    end
+    if useCache
+        if isempty(nCache)  % Determines cache size from free memory up to max 1GB
+            nCache = min([numel(x_rem)*5, ceil((min([sw_freemem, 1e9]) / 4) / (numel(fitstruc) * numel(fitstruc(1).y) * 3))]);
+        end
+        cache{iCache} = {x_rem, fitstruc};
+        iCache = iCache + 1;
+        if iCache > nCache
+            iCache = 1;
+        end
     end
 end
 
 yCalc = zeros(nY, 1);
 i0 = 1;
 for ii = 1:numel(data)
-    if param.fit_separate
-        sf = 1.0;
-        ssf = fminsearch(@(x)sum(abs(data(ii).y(:) - x*fitstruc(ii).y(:)), 'omitnan'), max(data(ii).y) / max(fitstruc(ii).y));
-        if ssf < 1e5
-            fitstruc(ii).y = ssf * fitstruc(ii).y;
-        end
+    %if param.fit_separate
+    %    sf = 1.0;
+    %    ssf = fminsearch(@(x)sum(abs(data(ii).y(:) - x*fitstruc(ii).y(:)), 'omitnan'), max(data(ii).y) / max(fitstruc(ii).y));
+    %    if ssf < 1e5
+    %        fitstruc(ii).y = ssf * fitstruc(ii).y;
+    %    end
+    %end
+    if sf ~= 1.0
+        fitstruc(ii).y = fitstruc(ii).y * sf;
     end
     i1 = i0 + numel(fitstruc(ii).y) - 1;
-    yCalc(i0:i1) = fitstruc(ii).y;
+    if ~isempty(param.bkgfun)
+        yCalc(i0:i1) = fitstruc(ii).y + param.bkgfun(data(ii).x, bkgpar);
+    else
+        yCalc(i0:i1) = fitstruc(ii).y;
+    end
     i0 = i1 + 1;
 end
 
-if param.fit_together
-    sf = fminsearch(@(x)sum(abs(lindat.y(:) - x*yCalc(:)), 'omitnan'), max(l0.y) / max(yCalc));
-end
+%if param.fit_together
+%    sf = fminsearch(@(x)sum(abs(lindat.y(:) - x*yCalc(:)), 'omitnan'), max(l0.y) / max(yCalc));
+%end
 
-if sf ~= 1.0
-    yCalc = sf * yCalc;
+yCalc(isnan(yCalc)) = 0;
+if ~param.imagChk
+    yCalc = abs(yCalc);
 end
 
 if param.plot
+    nR = ceil(nD / 4);
+    i0 = 1;
     for ii = 1:numel(data)
-        subplot(1, numel(data), ii);
+        subplot(nR, ceil(nD / nR), ii);
         try %#ok<TRYNC>
             delete(lines(ii));
         end
-        lines(ii) = plot(fitstruc(ii).x, sf * fitstruc(ii).y, '-r');
+        i1 = i0 + numel(fitstruc(ii).y) - 1;
+        lines(ii) = plot(fitstruc(ii).x, yCalc(i0:i1), '-r');
+        i0 = i1 + 1;
     end
     drawnow;
+end
+
+if param.verbose
+    fprintf('. chi2 = %d\n', sum((yCalc - lindat.y).^2 ./ lindat.e.^2) / numel(yCalc));
 end
 
 end

--- a/swfiles/sw_egrid.m
+++ b/swfiles/sw_egrid.m
@@ -477,7 +477,7 @@ if isfield(spectra,'omega')
     
     % Calculate Bose temperature factor for magnons
     if param.T==0
-        nBose = double(ebin_cens>=0);
+        nBose = find(ebin_cens<0);
     else
         nBose = 1./(exp(abs(ebin_cens)./(spectra.obj.unit.kB*param.T))-1)+double(ebin_cens>=0);
     end
@@ -507,7 +507,11 @@ if isfield(spectra,'omega')
                 DSF_valid(DSF_valid > param.maxDSF) = 0;
                 swConv{ii,tt} = accumarray(sw_conv_idx, DSF_valid(ien_valid), [nE, nHkl]);
                 % Multiply the intensities with the Bose factor.
-                swConv{ii,tt} = bsxfun(@times,swConv{ii,tt},nBose');
+                if param.T > 0
+                    swConv{ii,tt} = bsxfun(@times,swConv{ii,tt},nBose');
+                elseif ~isempty(nBose)
+                    swConv{ii,tt}(nBose,:) = 0;
+                end
                 swConv{ii,tt}(isnan(swConv{ii,tt})) = 0;
             else
                 swConv{ii,tt} = zeros(numel(ebin_cens), nHkl);
@@ -521,7 +525,7 @@ else
 end
 
 % sum up twin spectra if requested
-if param.sumtwin
+if param.sumtwin && nTwin > 1
     % normalised volume fractions of the twins
     if isfield(spectra,'obj')
         vol = spectra.obj.twin.vol/sum(spectra.obj.twin.vol);

--- a/swfiles/sw_freemem.m
+++ b/swfiles/sw_freemem.m
@@ -16,7 +16,21 @@ function mem = sw_freemem
 % `mem`
 % : Size of free memory in bytes.
 %
+persistent t0 m0;
+if isempty(t0) || isempty(m0)
+    m0 = get_free();
+    t0 = tic;
+else
+    if isempty(t0) || toc(t0) > 10    % poll only every 10 seconds
+        m0 = get_free();
+        t0 = tic;
+    end
+end
+mem = m0;
 
+end
+
+function mem = get_free()
 mem = 0;
 
 try %#ok<TRYNC>

--- a/swfiles/sw_instrument.m
+++ b/swfiles/sw_instrument.m
@@ -229,16 +229,19 @@ if param.dQ > 0
     stdG = param.dQ/2.35482;
     
     for jj = 1:nPlot
-        swConv = spectra.swConv{jj};
-        swConvTemp = swConv * 0;
-        for ii = 1:numel(Qconv)
-            % Gaussian with intensity normalised to 1, centered on E(ii)
-            fG = exp(-((Qconv-Qconv(ii))/stdG).^2/2);
-            fG = fG/sum(fG);
-            swConvTemp = swConvTemp + swConv(:,ii) * fG;
-            
+        if pref.usemex
+            spectra.swConv{jj} = sw_qconv(spectra.swConv{jj}, Qconv, stdG, pref.nthread);
+        else
+            swConv = spectra.swConv{jj};
+            swConvTemp = swConv * 0;
+            for ii = 1:numel(Qconv)
+                % Gaussian with intensity normalised to 1, centered on E(ii)
+                fG = exp(-((Qconv-Qconv(ii))/stdG).^2/2);
+                fG = fG/sum(fG);
+                swConvTemp = swConvTemp + swConv(:,ii) * fG;
+            end
+            spectra.swConv{jj} = swConvTemp;
         end
-        spectra.swConv{jj} = swConvTemp;
     end
     
     fprintf0(fid,'Finite instrumental momentum resolution of %5.3f A-1 is applied.\n',param.dQ);

--- a/swfiles/sw_mex.m
+++ b/swfiles/sw_mex.m
@@ -45,6 +45,7 @@ if param.compile
     chol_omp_dir = [sw_rootdir filesep 'external' filesep 'chol_omp'];
     mtimesx_dir = [sw_rootdir filesep 'external' filesep 'mtimesx'];
     swloop_dir = [sw_rootdir filesep 'external' filesep 'swloop'];
+    swqconv_dir = [sw_rootdir filesep 'external' filesep 'sw_qconv'];
     eigen_ver = '3.4.0';
     if ~exist([swloop_dir filesep 'eigen-' eigen_ver], 'dir')
         cd(swloop_dir);
@@ -97,6 +98,8 @@ if param.compile
         cd(swloop_dir);
         mex('-v','-R2018a',['-Ieigen-' eigen_ver],'swloop.cpp')
     end
+    cd(swqconv_dir);
+    mex('-R2018a','sw_qconv.cpp')
     % return back to original folder
     cd(aDir);
 end


### PR DESCRIPTION
Adds a method to fit powder data.

To test, run this script with the attached data:
[mnf2.mat.zip](https://github.com/SpinW/spinw/files/14001593/mnf2.mat.zip)

`cutpow.m`:
```matlab
function [xx, yy, ee] = cutpow(powstruct, qmin, qmax, emin, emax)
    xx = powstruct.x{1}.';
    if nargin < 5, emax = max(xx); end
    if nargin < 4, emin = min(xx); end
    ie0 = min(find(xx > emin));
    ie1 = max(find(xx <= emax));
    qq = powstruct.x{2};
    iq0 = min(find(qq > qmin));
    iq1 = max(find(qq <= qmax));
    yy = sum(powstruct.y(iq0:iq1, ie0:ie1), 1);
    ee = sqrt(sum(powstruct.e(iq0:iq1, ie0:ie1).^2, 1));
    xx = xx(ie0:ie1);
    if nargout == 1
        xx = struct('x', xx, 'y', yy, 'e', ee, 'qmin', qmin, 'qmax', qmax);
    end
end
```

```matlab
mnf2dat = load('mnf2.mat');
q0 = [0.7, 1.3, 2.0];
clear cts;
for iq = 1:numel(q0)
    cts(iq) = cutpow(mnf2dat, q0(iq)-0.1, q0(iq)+0.1, 1.0);
end

J1 = -0.05;
J2 = 0.3;
D = 0.05;

mnf2 = spinw;
mnf2.genlattice('lat_const', [4.87 4.87 3.31], 'angle', [90 90 90]*pi/180, 'sym', 'P 42/m n m');
mnf2.addatom('r', [0 0 0], 'S', 2.5, 'label', 'MMn2', 'color', 'b')
mnf2.gencoupling('maxDistance', 5)
mnf2.addmatrix('label', 'J1', 'value', J1, 'color', 'red');
mnf2.addmatrix('label', 'J2', 'value', J2, 'color', 'green');
mnf2.addcoupling('mat', 'J1', 'bond', 1)
mnf2.addcoupling('mat', 'J2', 'bond', 2)
mnf2.addmatrix('label', 'D', 'value', diag([0 0 D]), 'color', 'black');
mnf2.addaniso('D')
mnf2.genmagstr('mode', 'direct', 'S', [0 0; 0 0; 1 -1])

% Resolution (from PyChop)
Ei = 20;
eres = @(en) 512.17*sqrt((Ei-en)^3 * ( 8.26326e-10*(0.169+0.4*(Ei/(Ei-en))^1.5)^2 + 2.81618e-11*(1.169+0.4*(Ei/(Ei-en))^1.5)^2));
% Q-resolution (parameters for MARI)
e2k = @(en) sqrt( en .* (2*1.67492728e-27*1.60217653e-22) )./1.05457168e-34./1e10;
L1 = 11.8;  % Moderator to Sample distance in m
L2 = 2.5;   % Sample to detector distance in m
ws = 0.05;  % Width of sample in m
wm = 0.12;  % Width of moderator in m
wd = 0.025; % Width of detector in m
ki = e2k(25); 
a1 = ws/L1; % Angular width of sample seen from moderator
a2 = wm/L1; % Angular width of moderator seen from sample
a3 = wd/L2; % Angular width of detector seen from sample
a4 = ws/L2; % Angular width of sample seen from detector
dQ = 2.35 * sqrt( (ki*a1)^2/12 + (ki*a2)^2/12 + (ki*a3)^2/12 + (ki*a4)^2/12 );

fit_s = struct();
fit_s.func = @(obj, p) matparser(obj, 'param', p, 'mat', {'J1', 'J2', 'D(3,3)'}, 'init', true);
fit_s.x0 = [J1 J2 D];
fit_s.xmin = [-1 0 -0.2];  % Force J1 to be ferromagnetic to agree with structure
fit_s.xmax = [0 1 0.2];    % Force J2 to be antiferromagnetic to agree with structure
fit_s.hermit = false;
fit_s.formfact = true;
fit_s.nRand = 1e3;
fit_s.fibo = true;
fit_s.optimizer = 'lm3';   % Either: 'lm3' (Levenberg-Marquardt), 'pso' (Particle-Swarm), 'simplex' (Nelder-Mead)
fit_s.maxiter = 100;
fit_s.conv_func = @(spec) sw_instrument(spec, 'dE', eres, 'dQ', dQ, 'ThetaMin', 3.5, 'Ei', Ei);
fit_s.imagChk = false;
fit_s.nQ = 10;
fit_s.plot = true;
fit_s.intensity_scale = 15;    % Use a negative number if you don't want this to be fitted, set to zero to have a start value automatically determined
fit_s.background = 'linear';   % Either 'none', 'flat', 'linear' (x*p(1)+p(2)) or 'quadratic' (x.^2*p(1)+x*p(2)+p(3))
fit_s.background_par = [];     % Give either zero, 1, 2, or 3 numbers. If background is not 'none' and this is empty, the start params are auto-guessed 

fit_out = mnf2.fitpow(cts, fit_s)
```

It should take 1-2min to run the fit.

Note that for some reason, `lm` and `lm2` (there are 3 implementations of the Levenberg-Marquardt algorithm in `ndbase`) doesn't work but `lm3` does work.