### PR TITLE
Add energy resolution option when binning eigenvalues onto grid in sw_egrid

### DIFF
--- a/+sw_tests/+unit_tests/unittest_sw_egrid.m
+++ b/+sw_tests/+unit_tests/unittest_sw_egrid.m
@@ -376,7 +376,23 @@ classdef unittest_sw_egrid < sw_tests.unit_tests.unittest_super
             expected_out.swConv(455,3) = 2.65255873676699;
             testCase.verify_obj(out, expected_out);
         end
-        function test_dE_callable(testCase)
+        function test_dE_matrix_correct_numel(testCase)
+            % use small dE so only intenisty in a single ebin at each q
+            dE = 0.001*ones(1, numel(testCase.sw_egrid_out_sperp.Evect)-1);
+            out = sw_egrid(testCase.spectrum, 'component', 'Sperp', 'dE', dE);
+            expected_out = testCase.sw_egrid_out_sperp;
+            expected_out.swConv(228,[2, 4]) = 6.29705585872502e-05;
+            expected_out.swConv(455,3) = 2.65255873676699;
+            testCase.verify_obj(out, expected_out);
+        end
+        function test_dE_matrix_incorrect_numel(testCase)
+            % use small dE so only intenisty in a single ebin at each q
+            dE = [0.001, 0.001];
+            testCase.verifyError(...
+                @() sw_egrid(testCase.spectrum, 'component', 'Sperp', 'dE', dE), ...
+                'sw_egrid:WrongInput');
+        end
+        function test_dE_callable_func(testCase)
             % use small dE so only intenisty in a single ebin at each q
             dE_func = @(en) 0.001;
             out = sw_egrid(testCase.spectrum, 'component', 'Sperp', 'dE', dE_func);

--- a/+sw_tests/+unit_tests/unittest_sw_egrid.m
+++ b/+sw_tests/+unit_tests/unittest_sw_egrid.m
@@ -369,7 +369,7 @@ classdef unittest_sw_egrid < sw_tests.unit_tests.unittest_super
             testCase.verify_obj(out, expected_out);
         end
         function test_dE_single_number(testCase)
-            % use small dE so only intenisty in a single ebin at each q
+            % use small dE so only intensity in a single ebin at each q
             out = sw_egrid(testCase.spectrum, 'component', 'Sperp', 'dE', 0.001);
             expected_out = testCase.sw_egrid_out_sperp;
             expected_out.swConv(228,[2, 4]) = 6.29705585872502e-05;
@@ -377,7 +377,7 @@ classdef unittest_sw_egrid < sw_tests.unit_tests.unittest_super
             testCase.verify_obj(out, expected_out);
         end
         function test_dE_matrix_correct_numel(testCase)
-            % use small dE so only intenisty in a single ebin at each q
+            % use small dE so only intensity in a single ebin at each q
             dE = 0.001*ones(1, numel(testCase.sw_egrid_out_sperp.Evect)-1);
             out = sw_egrid(testCase.spectrum, 'component', 'Sperp', 'dE', dE);
             expected_out = testCase.sw_egrid_out_sperp;
@@ -386,14 +386,14 @@ classdef unittest_sw_egrid < sw_tests.unit_tests.unittest_super
             testCase.verify_obj(out, expected_out);
         end
         function test_dE_matrix_incorrect_numel(testCase)
-            % use small dE so only intenisty in a single ebin at each q
+            % use small dE so only intensity in a single ebin at each q
             dE = [0.001, 0.001];
             testCase.verifyError(...
                 @() sw_egrid(testCase.spectrum, 'component', 'Sperp', 'dE', dE), ...
                 'sw_egrid:WrongInput');
         end
         function test_dE_callable_func(testCase)
-            % use small dE so only intenisty in a single ebin at each q
+            % use small dE so only intensity in a single ebin at each q
             dE_func = @(en) 0.001;
             out = sw_egrid(testCase.spectrum, 'component', 'Sperp', 'dE', dE_func);
             expected_out = testCase.sw_egrid_out_sperp;

--- a/+sw_tests/+unit_tests/unittest_sw_egrid.m
+++ b/+sw_tests/+unit_tests/unittest_sw_egrid.m
@@ -368,6 +368,23 @@ classdef unittest_sw_egrid < sw_tests.unit_tests.unittest_super
             expected_out.swConv = zeros(size(expected_out.swConv));
             testCase.verify_obj(out, expected_out);
         end
+        function test_dE_single_number(testCase)
+            % use small dE so only intenisty in a single ebin at each q
+            out = sw_egrid(testCase.spectrum, 'component', 'Sperp', 'dE', 0.001);
+            expected_out = testCase.sw_egrid_out_sperp;
+            expected_out.swConv(228,[2, 4]) = 6.29705585872502e-05;
+            expected_out.swConv(455,3) = 2.65255873676699;
+            testCase.verify_obj(out, expected_out);
+        end
+        function test_dE_callable(testCase)
+            % use small dE so only intenisty in a single ebin at each q
+            dE_func = @(en) 0.001;
+            out = sw_egrid(testCase.spectrum, 'component', 'Sperp', 'dE', dE_func);
+            expected_out = testCase.sw_egrid_out_sperp;
+            expected_out.swConv(228,[2, 4]) = 6.29705585872502e-05;
+            expected_out.swConv(455,3) = 2.65255873676699;
+            testCase.verify_obj(out, expected_out);
+        end
     end
 
 end

--- a/swfiles/sw_egrid.m
+++ b/swfiles/sw_egrid.m
@@ -132,7 +132,8 @@ function spectra = sw_egrid(spectra, varargin)
 %   smaller than the energy bin size. Default value is true.
 %
 % `dE`
-% : Energy resolution (FWHM) can be function, or a single number
+% : Energy resolution (FWHM) can be function, or a numeric matrix that
+%   has length 1 or the numeber of energy bin centers.
 % 
 % {{note The Blume-Maleev coordinate system is a cartesian coordinate
 % system with $x_{BM}$, $y_{BM}$ and $z_{BM}$ basis vectors defined as:
@@ -464,8 +465,16 @@ nE = numel(ebin_cens);
 % evalulate reoslution at every bin-center if func
 if isa(param.dE,'function_handle')
     dE_sigma = param.dE(ebin_cens(:))/2.355;
-else
+elseif isnumeric(param.dE)
+    n_dE = numel(param.dE);
+    if n_dE > 1 && n_dE ~= nE
+        error('sw_egrid:WrongInput', ['numeric dE must be on length 1 ' ...
+              'or number of energy bin centers'])
+    end
     dE_sigma = param.dE(:)/2.355;
+else
+    error('sw_egrid:WrongInput', ['dE must be a numeric matrix or a ' ...
+          'callable function']);
 end
 
 

--- a/swfiles/sw_egrid.m
+++ b/swfiles/sw_egrid.m
@@ -133,7 +133,7 @@ function spectra = sw_egrid(spectra, varargin)
 %
 % `dE`
 % : Energy resolution (FWHM) can be function, or a numeric matrix that
-%   has length 1 or the numeber of energy bin centers.
+%   has length 1 or the number of energy bin centers.
 % 
 % {{note The Blume-Maleev coordinate system is a cartesian coordinate
 % system with $x_{BM}$, $y_{BM}$ and $z_{BM}$ basis vectors defined as:
@@ -464,7 +464,7 @@ nE = numel(ebin_cens);
 
 % evalulate reoslution at every bin-center if func
 if isa(param.dE,'function_handle')
-    dE_sigma = param.dE(ebin_cens(:))/2.355;
+    dE_sigma = param.dE(ebin_cens(:))/2*sqrt(2*log(2)); % convert from FWHM
 elseif isnumeric(param.dE)
     n_dE = numel(param.dE);
     if n_dE > 1 && n_dE ~= nE


### PR DESCRIPTION
This issue was found during testing of #164 - when fitting powder spectra with resolution convolution, performing the convolution in energy after the binning was leading to large discontinuities in the cost function derivatives wert the parameters.

This PR accounts for the energy resolution 'properly' by considering the resolution at the point the intensity at each eigenvalue is binned onto a grid. Note it assumes the energy resolution is Gaussian and is separable from the Q resolution.