### PR TITLE
sw_fitpower improvements

### DIFF
--- a/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
+++ b/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
@@ -72,6 +72,15 @@ classdef unittest_sw_fitpowder < sw_tests.unit_tests.unittest_super
             testCase.verify_results(out, expected_fitpow);
         end
 
+        function test_set_background_strategy(testCase)
+            out = sw_fitpowder(testCase.swobj, testCase.data_1d_cuts, ...
+                               testCase.fit_func, testCase.j1, "independent");
+            out.set_background_strategy("planar");
+            expected_fitpow = testCase.default_fitpow;
+            expected_fitpow.modQ_cens = testCase.default_modQ_cens_1d;
+            testCase.verify_results(out, expected_fitpow);
+        end
+
         function test_replace_2D_data_with_1D_cuts(testCase)
             out = sw_fitpowder(testCase.swobj, testCase.data_2d, ...
                                testCase.fit_func, testCase.j1);
@@ -82,7 +91,7 @@ classdef unittest_sw_fitpowder < sw_tests.unit_tests.unittest_super
             testCase.verify_results(out, expected_fitpow);
         end
 
-        function test_replace_2D_data_with_1D_cuts_sepcify_bg(testCase)
+        function test_replace_2D_data_with_1D_cuts_specify_bg(testCase)
             out = sw_fitpowder(testCase.swobj, testCase.data_2d, ...
                                testCase.fit_func, testCase.j1);
             qcens = [4, 5];

--- a/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
+++ b/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
@@ -341,6 +341,18 @@ classdef unittest_sw_fitpowder < sw_tests.unit_tests.unittest_super
             testCase.verify_results(out, expected_fitpow);
         end
 
+        function test_reset_errors_of_bg_bins(testCase)
+            out = sw_fitpowder(testCase.swobj, testCase.data_2d, ...
+                               testCase.fit_func, testCase.j1);
+            out.y(1) = 10;  % high so other bins are background
+            out.set_errors_of_bg_bins(100);
+            out.reset_errors_of_bg_bins();
+            expected_fitpow = testCase.default_fitpow;
+            expected_fitpow.y(1) = 10;
+            expected_fitpow.ibg = [3;6;2;5;4];
+            testCase.verify_results(out, expected_fitpow);
+        end
+
         function test_estimate_scale_factor(testCase)
             out = sw_fitpowder(testCase.swobj, testCase.data_2d, ...
                                testCase.fit_func, testCase.j1);

--- a/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
+++ b/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
@@ -71,6 +71,30 @@ classdef unittest_sw_fitpowder < sw_tests.unit_tests.unittest_super
             testCase.verify_results(out, expected_fitpow);
         end
 
+        function test_replace_2D_data_with_1D_cuts(testCase)
+            out = sw_fitpowder(testCase.swobj, testCase.data_2d, ...
+                               testCase.fit_func, testCase.j1);
+            qcens = [4, 5];
+            out.replace_2D_data_with_1D_cuts(qcens-0.5, qcens+0.5)
+            expected_fitpow = testCase.default_fitpow;
+            expected_fitpow.modQ_cens = testCase.default_modQ_cens_1d;
+            testCase.verify_results(out, expected_fitpow);
+        end
+
+        function test_replace_2D_data_with_1D_cuts_sepcify_bg(testCase)
+            out = sw_fitpowder(testCase.swobj, testCase.data_2d, ...
+                               testCase.fit_func, testCase.j1);
+            qcens = [4, 5];
+            out.replace_2D_data_with_1D_cuts(qcens-0.5, qcens+0.5,...
+                                             "independent")
+            expected_fitpow = testCase.default_fitpow;
+            expected_fitpow.modQ_cens = testCase.default_modQ_cens_1d;
+            % add extra background param
+            expected_fitpow.params = expected_fitpow.params([1:2,2:end],:);
+            expected_fitpow.bounds = expected_fitpow.bounds([1:2,2:end],:);
+            testCase.verify_results(out, expected_fitpow);
+        end
+
         function test_init_data_1d_specify_nQ(testCase)
             out = sw_fitpowder(testCase.swobj, testCase.data_1d_cuts, ...
                                testCase.fit_func, testCase.j1, "planar", 1);

--- a/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
+++ b/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
@@ -300,6 +300,21 @@ classdef unittest_sw_fitpowder < sw_tests.unit_tests.unittest_super
             testCase.verify_results(out, expected_fitpow);
         end
 
+        function test_fit_background(testCase)
+            out = sw_fitpowder(testCase.swobj, testCase.data_2d, ...
+                               testCase.fit_func, testCase.j1);
+            out.fix_bg_parameters(1:2); % fix slopes of background to 0
+            out.set_bg_parameters(3, 1.5); % initial guess
+            out.fit_background()
+            expected_fitpow = testCase.default_fitpow;
+            expected_fitpow.params(end-1) = 1;
+            expected_fitpow.bounds(2:3,:) = 0; % fixed bg slopes
+            expected_fitpow.ibg = [4];
+            testCase.verify_results(out, expected_fitpow, ...
+                                    testCase.default_fields, ...
+                                    'abs_tol', 1e-3);
+        end
+
         function test_set_errors_of_bg_bins(testCase)
             out = sw_fitpowder(testCase.swobj, testCase.data_2d, ...
                                testCase.fit_func, testCase.j1);

--- a/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
+++ b/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
@@ -290,37 +290,53 @@ classdef unittest_sw_fitpowder < sw_tests.unit_tests.unittest_super
             testCase.verify_results(out, expected_fitpow);
         end
 
+        function test_estimate_constant_background_fails(testCase)
+            out = sw_fitpowder(testCase.swobj, testCase.data_2d, ...
+                               testCase.fit_func, testCase.j1);
+            % background estimation fails as no minimum in skew
+            testCase.verifyError(...
+                @() out.estimate_constant_background(), ...
+                'spinw:find_indices_and_mean_of_bg_bins');
+            testCase.verify_results(out, testCase.default_fitpow);
+        end
+
         function test_estimate_constant_background(testCase)
             out = sw_fitpowder(testCase.swobj, testCase.data_2d, ...
                                testCase.fit_func, testCase.j1);
-            out.estimate_constant_background()
+            out.y(1) = 10;  % higher so other bins are background
+            out.estimate_constant_background();
             expected_fitpow = testCase.default_fitpow;
-            expected_fitpow.params(end-1) = 1;
-            expected_fitpow.ibg = [4];
+            expected_fitpow.y(1) = 10;
+            expected_fitpow.ibg = [3;6;2;5;4];
+            expected_fitpow.params(end-1) = 2.2;
             testCase.verify_results(out, expected_fitpow);
         end
 
         function test_fit_background(testCase)
             out = sw_fitpowder(testCase.swobj, testCase.data_2d, ...
                                testCase.fit_func, testCase.j1);
+            out.y(1) = 10;  % higher so other bins are background
             out.fix_bg_parameters(1:2); % fix slopes of background to 0
             out.set_bg_parameters(3, 1.5); % initial guess
             out.fit_background()
             expected_fitpow = testCase.default_fitpow;
-            expected_fitpow.params(end-1) = 1;
+            expected_fitpow.y(1) = 10;
+            expected_fitpow.ibg = [3;6;2;5;4];
+            expected_fitpow.params(end-1) = 2.2002;
             expected_fitpow.bounds(2:3,:) = 0; % fixed bg slopes
-            expected_fitpow.ibg = [4];
             testCase.verify_results(out, expected_fitpow, ...
                                     testCase.default_fields, ...
-                                    'abs_tol', 1e-3);
+                                    'abs_tol', 1e-4);
         end
 
         function test_set_errors_of_bg_bins(testCase)
             out = sw_fitpowder(testCase.swobj, testCase.data_2d, ...
                                testCase.fit_func, testCase.j1);
+            out.y(1) = 10;  % high so other bins are background
             out.set_errors_of_bg_bins(100);
             expected_fitpow = testCase.default_fitpow;
-            expected_fitpow.ibg = [4];
+            expected_fitpow.y(1) = 10;
+            expected_fitpow.ibg = [3;6;2;5;4];
             expected_fitpow.e(expected_fitpow.ibg) = 100;
             testCase.verify_results(out, expected_fitpow);
         end

--- a/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
+++ b/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
@@ -28,7 +28,8 @@ classdef unittest_sw_fitpowder < sw_tests.unit_tests.unittest_super
                                                         -Inf   Inf;
                                                         -Inf   Inf;
                                                         -Inf   Inf;
-                                                           0   Inf]);
+                                                           0   Inf], ...
+                                              'ibg', []);
             testCase.default_fields = fieldnames(testCase.default_fitpow);
         end
     end
@@ -295,6 +296,17 @@ classdef unittest_sw_fitpowder < sw_tests.unit_tests.unittest_super
             out.estimate_constant_background()
             expected_fitpow = testCase.default_fitpow;
             expected_fitpow.params(end-1) = 1;
+            expected_fitpow.ibg = [4];
+            testCase.verify_results(out, expected_fitpow);
+        end
+
+        function test_set_errors_of_bg_bins(testCase)
+            out = sw_fitpowder(testCase.swobj, testCase.data_2d, ...
+                               testCase.fit_func, testCase.j1);
+            out.set_errors_of_bg_bins(100);
+            expected_fitpow = testCase.default_fitpow;
+            expected_fitpow.ibg = [4];
+            expected_fitpow.e(expected_fitpow.ibg) = 100;
             testCase.verify_results(out, expected_fitpow);
         end
 

--- a/swfiles/sw_fitpowder.m
+++ b/swfiles/sw_fitpowder.m
@@ -521,6 +521,39 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
             xlim(ax, [obj.modQ_cens(1), obj.modQ_cens(end)]);
         end
 
+        function plot_1d_cuts_of_2d_data(obj, qmins, qmaxs, params)
+            % optionally plot ycalc provided, otherwise will plot
+            % fitpow.ycalc if not empty
+            assert(obj.ndim ==2, ...
+                   'sw_fitpowder:invalidinput', ...
+                   'This function is only valid for 2D data');
+            if nargin > 3
+                [ycalc, ~] = obj.calc_spinwave_spec(params);
+            else
+                ycalc = [];
+            end
+            figure("color","white");
+            ncuts = numel(qmins);
+            for icut = 1:ncuts
+                ikeep = obj.modQ_cens > qmins(icut) & obj.modQ_cens <= qmaxs(icut);
+                ax =  subplot(1, ncuts, icut);
+                hold on; box on;
+                ycut = sum(obj.y(:,ikeep), 2);
+                plot(ax, obj.ebin_cens, ycut, 'ok');
+                if ~isempty(ycalc)
+                    plot(ax, obj.ebin_cens, sum(ycalc(:,ikeep), 2), '-r');
+                end
+                % calc xlims
+                ifinite = isfinite(ycut);
+                istart = find(ifinite, 1, 'first');
+                iend = find(ifinite, 1, 'last');
+                xlim(ax, [obj.ebin_cens(istart), obj.ebin_cens(iend)]);
+                xlabel(ax, 'Energy (meV)')
+                ylabel(ax, 'Intensity');
+                title(ax, num2str(0.5*(qmaxs(icut)+qmins(icut)), 2) + " $\AA^{-1}$", 'interpreter','latex')
+            end
+        end
+
     end
 
     % private

--- a/swfiles/sw_fitpowder.m
+++ b/swfiles/sw_fitpowder.m
@@ -470,6 +470,16 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
             obj.set_bg_parameters(obj.nparams_bg, bg);  % set constant background
         end
 
+        function set_errors_of_bg_bins(obj, val)
+            if isempty(obj.ibg)
+                obj.find_indices_and_mean_of_bg_bins();
+            end
+            if nargin < 2
+                val = max(obj.e(obj.ibg));
+            end
+            obj.e(obj.ibg) = val;
+        end
+
         function plot_result(obj, params, varargin)
             [ycalc, ~] = obj.calc_spinwave_spec(params);
             obj.plot_1d_or_2d(ycalc, varargin{:});

--- a/swfiles/sw_fitpowder.m
+++ b/swfiles/sw_fitpowder.m
@@ -171,6 +171,10 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
        liveplot_counter = 0
        ibg = []
     end
+
+   properties (Constant)
+      zero_error_tol = 10*eps
+   end
         
     methods       
         function obj = sw_fitpowder(swobj, data, fit_func, model_params, background_strategy, nQ)
@@ -610,7 +614,7 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
                 resid = resid./e;
             end
             % exclude nans in both ycalc and input data
-            ikeep = isfinite(resid) & e > 10*eps;
+            ikeep = isfinite(resid) & e > obj.zero_error_tol;
             resid_sq_sum = resid(ikeep)'*resid(ikeep);
         end
 

--- a/swfiles/sw_fitpowder.m
+++ b/swfiles/sw_fitpowder.m
@@ -428,7 +428,7 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
                 resid = resid./(obj.e);
             end
             % exclude nans in both ycalc and input data
-            ikeep = isfinite(resid);
+            ikeep = isfinite(resid) & obj.e > 1e-12;
             resid_sq_sum = resid(ikeep)'*resid(ikeep);
         end
 

--- a/swfiles/sw_fitpowder.m
+++ b/swfiles/sw_fitpowder.m
@@ -461,7 +461,7 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
             prev_skew = inf;
             for ipt = 1:numel(ysort)
                 this_mean = mean(ysort(ipt:end));
-                this_skew = mean((ysort(ipt:end) - this_mean).^3)/(std(ysort(ipt:end)).^3);
+                this_skew = mean((ysort(ipt:end) - this_mean).^3);
                 if this_skew < 0 || this_skew > prev_skew
                     bg = this_mean;
                     break
@@ -516,6 +516,7 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
             ylim(ax, [obj.ebin_cens(1), obj.ebin_cens(end)]);
             xlim(ax, [obj.modQ_cens(1), obj.modQ_cens(end)]);
         end
+
     end
 
     % private

--- a/swfiles/sw_fitpowder.m
+++ b/swfiles/sw_fitpowder.m
@@ -430,7 +430,7 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
                 resid = resid./(obj.e);
             end
             % exclude nans in both ycalc and input data
-            ikeep = isfinite(resid) & obj.e > 1e-12;
+            ikeep = isfinite(resid) & obj.e > 10*eps;
             resid_sq_sum = resid(ikeep)'*resid(ikeep);
         end
 

--- a/swfiles/sw_fitpowder.m
+++ b/swfiles/sw_fitpowder.m
@@ -170,6 +170,7 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
        model_params_cached = []
        liveplot_counter = 0
        ibg = []
+       bg_errors = []
     end
 
    properties (Constant)
@@ -404,6 +405,7 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
             obj.ycalc_cached = [];
             obj.model_params_cached = [];
             obj.ibg = [];
+            obj.reset_errors_of_bg_bins()
         end
 
         function [ycalc, bg] = calc_spinwave_spec(obj, params)
@@ -535,7 +537,15 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
             if nargin < 2
                 val = max(obj.e(obj.ibg));
             end
+            obj.bg_errors = obj.e(obj.ibg); % save values so can reset
             obj.e(obj.ibg) = val;
+        end
+
+        function reset_errors_of_bg_bins(obj)
+            if ~isempty(obj.ibg) && ~isempty(obj.bg_errors)
+                obj.e(obj.ibg) = obj.bg_errors;
+            end
+            obj.bg_errors = [];
         end
 
         function plot_result(obj, params, varargin)


### PR DESCRIPTION
Some improvements to `sw_fitpowder` after a first round of testing with users:

* Ignores very small errors (less than `10*eps` or around `2e-15`) - this makes fitting with `chi^2` better as these errors were constraining the fit too much.
* Add functions to cut 1D sets from an input 2D data
* Improve functions to estimate and fit background
* Add ability to set the error on background points to an arbitrary value (if they are somehow too small and thus constrain `chi^2` too much).