### PR TITLE
Refactor simplex to use wrapper class handling bound and fixed parameters

### DIFF
--- a/+sw_tests/+unit_tests/unittest_ndbase_cost_function_wrapper.m
+++ b/+sw_tests/+unit_tests/unittest_ndbase_cost_function_wrapper.m
@@ -1,0 +1,104 @@
+classdef unittest_ndbase_cost_function_wrapper < sw_tests.unit_tests.unittest_super
+    % Runs through unit test for ndbase optimisers, atm only simplex passes
+    % these tests
+
+    properties
+        fcost = @(p) (p(1)-1)^2 + (p(2)-2)^2
+        params = [2,4]
+    end
+
+    properties (TestParameter)
+        bound_param_name = {'lb', 'ub'}
+        no_lower_bound = {[], [-inf, -inf]};
+        no_upper_bound = {[], [inf, inf]};
+    end
+
+    methods
+        function [pfree, pbound, cost_val] = get_pars_and_cost_val(testCase, cost_func_wrap)
+            pfree = cost_func_wrap.get_free_parameters(testCase.params);
+            pbound = cost_func_wrap.get_bound_parameters(pfree);
+            cost_val = cost_func_wrap.eval_cost_function(pfree);
+        end
+    end
+
+    methods (Test)
+
+        function test_init_with_fcost_no_bounds(testCase)
+            cost_func_wrap = ndbase.cost_function_wrapper(testCase.fcost, testCase.params);
+            [pfree, pbound, cost_val] = testCase.get_pars_and_cost_val(cost_func_wrap);
+            testCase.verify_val(pfree, testCase.params);
+            testCase.verify_val(pbound, testCase.params);
+            testCase.verify_val(cost_val, testCase.fcost(pbound), 'abs_tol', 1e-4);
+        end
+
+        function test_init_with_fcost_no_bounds_name_value_passed(testCase, no_lower_bound, no_upper_bound)
+            cost_func_wrap = ndbase.cost_function_wrapper(testCase.fcost, testCase.params, 'lb', no_lower_bound, 'ub', no_upper_bound);
+            [pfree, pbound, cost_val] = testCase.get_pars_and_cost_val(cost_func_wrap);
+            testCase.verify_val(pfree, testCase.params);
+            testCase.verify_val(pbound, testCase.params);
+            testCase.verify_val(cost_val, testCase.fcost(pbound), 'abs_tol', 1e-4);
+        end
+
+        function test_init_with_fcost_lower_bound_only(testCase)
+            % note first param outside bounds
+            cost_func_wrap = ndbase.cost_function_wrapper(testCase.fcost, testCase.params, 'lb', [3, 1]);
+            [pfree, pbound, cost_val] = testCase.get_pars_and_cost_val(cost_func_wrap);
+            testCase.verify_val(pfree, [0, 3.8730], 'abs_tol', 1e-4);
+            testCase.verify_val(pbound, [3, 4], 'abs_tol', 1e-4);
+            testCase.verify_val(cost_val, testCase.fcost(pbound), 'abs_tol', 1e-4);
+        end
+
+        function test_init_with_fcost_upper_bound_only(testCase)
+            % note second param outside bounds
+            cost_func_wrap = ndbase.cost_function_wrapper(testCase.fcost, testCase.params, 'ub', [3, 1]);
+            [pfree, pbound, cost_val] = testCase.get_pars_and_cost_val(cost_func_wrap);
+            testCase.verify_val(pfree, [1.7320, 0], 'abs_tol', 1e-4);
+            testCase.verify_val(pbound, [2, 1], 'abs_tol', 1e-4);
+            testCase.verify_val(cost_val, testCase.fcost(pbound), 'abs_tol', 1e-4);
+        end
+
+        function test_init_with_fcost_both_bounds(testCase)
+            % note second param outside bounds
+            cost_func_wrap = ndbase.cost_function_wrapper(testCase.fcost, testCase.params, 'lb', [1, 2], 'ub', [3, 2.5]);
+            [pfree, pbound, cost_val] = testCase.get_pars_and_cost_val(cost_func_wrap);
+            testCase.verify_val(pfree, [0, 1.5708], 'abs_tol', 1e-4);
+            testCase.verify_val(pbound, [2, 2.5], 'abs_tol', 1e-4);
+            testCase.verify_val(cost_val, testCase.fcost(pbound), 'abs_tol', 1e-4);
+        end
+
+        function test_init_with_fcost_both_bounds_with_fixed_param(testCase)
+            % note second param outside bounds
+            cost_func_wrap = ndbase.cost_function_wrapper(testCase.fcost, testCase.params, 'lb', [1, 2.5], 'ub', [3, 2.5]);
+            [pfree, pbound, cost_val] = testCase.get_pars_and_cost_val(cost_func_wrap);
+            testCase.verify_val(pfree, 0, 'abs_tol', 1e-4);  % only first param free
+            testCase.verify_val(pbound, [2, 2.5], 'abs_tol', 1e-4);
+            testCase.verify_val(cost_val, testCase.fcost(pbound), 'abs_tol', 1e-4);
+            testCase.verify_val(cost_func_wrap.ifixed, 2);
+            testCase.verify_val(cost_func_wrap.ifree, 1);
+            testCase.verify_val(cost_func_wrap.pars_fixed, 2.5);
+        end
+
+        function test_init_with_data(testCase)
+            dat = struct('x', 1:3, 'e', ones(1,3));
+            dat.y = polyval(testCase.params, dat.x);
+            cost_func_wrap = ndbase.cost_function_wrapper(@(x, p) polyval(p, x), testCase.params, 'data', dat);
+            [pfree, pbound, cost_val] = testCase.get_pars_and_cost_val(cost_func_wrap);
+            testCase.verify_val(pfree, testCase.params, 'abs_tol', 1e-4);
+            testCase.verify_val(pbound, testCase.params, 'abs_tol', 1e-4);
+            testCase.verify_val(cost_val, 0, 'abs_tol', 1e-4);
+        end
+
+        function test_wrong_size_bounds(testCase, bound_param_name)
+            testCase.verifyError(...
+                @() ndbase.cost_function_wrapper(testCase.fcost, testCase.params, bound_param_name, ones(3)), ...
+                'ndbase:cost_function:WrongInput');
+        end
+
+        function test_incompatible_bounds(testCase)
+            testCase.verifyError(...
+                @() ndbase.cost_function_wrapper(testCase.fcost, testCase.params, 'lb', [1,1,], 'ub', [0,0]), ...
+                'ndbase:cost_function:WrongInput');
+        end
+        
+    end
+end

--- a/+sw_tests/+unit_tests/unittest_ndbase_cost_function_wrapper.m
+++ b/+sw_tests/+unit_tests/unittest_ndbase_cost_function_wrapper.m
@@ -9,8 +9,8 @@ classdef unittest_ndbase_cost_function_wrapper < sw_tests.unit_tests.unittest_su
 
     properties (TestParameter)
         bound_param_name = {'lb', 'ub'}
-        no_lower_bound = {[], [-inf, -inf]};
-        no_upper_bound = {[], [inf, inf]};
+        no_lower_bound = {[], [-inf, -inf], [NaN, -inf]};
+        no_upper_bound = {[], [inf, inf], [inf, NaN]};
         errors = {ones(1,3), [], zeros(1,3), 'NoField'}
     end
 

--- a/+sw_tests/+unit_tests/unittest_ndbase_cost_function_wrapper.m
+++ b/+sw_tests/+unit_tests/unittest_ndbase_cost_function_wrapper.m
@@ -11,6 +11,7 @@ classdef unittest_ndbase_cost_function_wrapper < sw_tests.unit_tests.unittest_su
         bound_param_name = {'lb', 'ub'}
         no_lower_bound = {[], [-inf, -inf]};
         no_upper_bound = {[], [inf, inf]};
+        errors = {ones(1,3), [], zeros(1,3), 'NoField'}
     end
 
     methods
@@ -78,8 +79,14 @@ classdef unittest_ndbase_cost_function_wrapper < sw_tests.unit_tests.unittest_su
             testCase.verify_val(cost_func_wrap.pars_fixed, 2.5);
         end
 
-        function test_init_with_data(testCase)
-            dat = struct('x', 1:3, 'e', ones(1,3));
+        function test_init_with_data(testCase, errors)
+            % all errors passed lead to unweighted residuals (either as
+            % explicitly ones or the default weights if invalid errors)
+            if ischar(errors) && errors == "NoField"
+                dat = struct('x', 1:3);
+            else
+                dat = struct('x', 1:3, 'e', errors);
+            end
             dat.y = polyval(testCase.params, dat.x);
             cost_func_wrap = ndbase.cost_function_wrapper(@(x, p) polyval(p, x), testCase.params, 'data', dat);
             [pfree, pbound, cost_val] = testCase.get_pars_and_cost_val(cost_func_wrap);
@@ -91,13 +98,13 @@ classdef unittest_ndbase_cost_function_wrapper < sw_tests.unit_tests.unittest_su
         function test_wrong_size_bounds(testCase, bound_param_name)
             testCase.verifyError(...
                 @() ndbase.cost_function_wrapper(testCase.fcost, testCase.params, bound_param_name, ones(3)), ...
-                'ndbase:cost_function:WrongInput');
+                'ndbase:cost_function_wrapper:WrongInput');
         end
 
         function test_incompatible_bounds(testCase)
             testCase.verifyError(...
                 @() ndbase.cost_function_wrapper(testCase.fcost, testCase.params, 'lb', [1,1,], 'ub', [0,0]), ...
-                'ndbase:cost_function:WrongInput');
+                'ndbase:cost_function_wrapper:WrongInput');
         end
         
     end

--- a/+sw_tests/+unit_tests/unittest_ndbase_cost_function_wrapper.m
+++ b/+sw_tests/+unit_tests/unittest_ndbase_cost_function_wrapper.m
@@ -79,6 +79,30 @@ classdef unittest_ndbase_cost_function_wrapper < sw_tests.unit_tests.unittest_su
             testCase.verify_val(cost_func_wrap.pars_fixed, 2.5);
         end
 
+
+        function test_init_with_fcost_both_bounds_with_fixed_param_using_ifix(testCase)
+            % note second param outside bounds
+            cost_func_wrap = ndbase.cost_function_wrapper(testCase.fcost, testCase.params, 'lb', [1, 2], 'ub', [3, 2.5], 'ifix', [2]);
+            [pfree, pbound, cost_val] = testCase.get_pars_and_cost_val(cost_func_wrap);
+            testCase.verify_val(pfree, 0, 'abs_tol', 1e-4);  % only first param free
+            testCase.verify_val(pbound, [2, 2.5], 'abs_tol', 1e-4);
+            testCase.verify_val(cost_val, testCase.fcost(pbound), 'abs_tol', 1e-4);
+            testCase.verify_val(cost_func_wrap.ifixed, 2);
+            testCase.verify_val(cost_func_wrap.ifree, 1);
+            testCase.verify_val(cost_func_wrap.pars_fixed, 2.5);
+        end
+
+        function test_init_with_fcost_no_bounds_with_fixed_param_using_ifix(testCase)
+            % note second param outside bounds
+            cost_func_wrap = ndbase.cost_function_wrapper(testCase.fcost, testCase.params, 'ifix', [2]);
+            [pfree, pbound, cost_val] = testCase.get_pars_and_cost_val(cost_func_wrap);
+            testCase.verify_val(pfree, testCase.params(1), 'abs_tol', 1e-4);  % only first param free
+            testCase.verify_val(pbound, testCase.params, 'abs_tol', 1e-4);
+            testCase.verify_val(cost_func_wrap.ifixed, 2);
+            testCase.verify_val(cost_func_wrap.ifree, 1);
+            testCase.verify_val(cost_func_wrap.pars_fixed, testCase.params(2));
+        end
+
         function test_init_with_data(testCase, errors)
             % all errors passed lead to unweighted residuals (either as
             % explicitly ones or the default weights if invalid errors)

--- a/+sw_tests/+unit_tests/unittest_ndbase_optimisers.m
+++ b/+sw_tests/+unit_tests/unittest_ndbase_optimisers.m
@@ -1,0 +1,72 @@
+classdef unittest_ndbase_optimisers < sw_tests.unit_tests.unittest_super
+    % Runs through unit test for ndbase optimisers, atm only simplex passes
+    % these tests
+
+    properties
+        rosenbrock = @(x) (1-x(1)).^2 + 100*(x(2) - x(1).^2).^2;
+        rosenbrock_minimum = [1, 1];
+        poly_func = @(x, p) polyval(p, x)
+    end
+
+    properties (TestParameter)
+        optimiser = {@ndbase.simplex};
+    end
+
+    methods (Test)
+        function test_optimise_data_struct(testCase, optimiser)
+            linear_pars = [2, 1];
+            dat = struct('x', 1:3, 'e', ones(1,3));
+            dat.y = testCase.poly_func(dat.x, linear_pars);
+            [pars_fit, cost_val, ~] = optimiser(dat, testCase.poly_func, [-1,-1]);
+            testCase.verify_val(pars_fit, linear_pars, 'abs_tol', 1e-3);
+            testCase.verify_val(cost_val, 2.5e-7, 'abs_tol', 1e-8);
+        end
+
+        function test_optimise_rosen_free(testCase, optimiser)
+            [pars_fit, cost_val, ~] = optimiser([], testCase.rosenbrock, [-1,-1]);
+            testCase.verify_val(pars_fit, testCase.rosenbrock_minimum, 'abs_tol', 1e-3);
+            testCase.verify_val(cost_val, 0, 'abs_tol', 1e-6);
+        end
+
+        function test_optimise_rosen_lower_bound_minimum_accessible(testCase, optimiser)
+            [pars_fit, cost_val, ~] = optimiser([], testCase.rosenbrock, [-1,-1], 'lb', [-2, -2]);
+            testCase.verify_val(pars_fit, testCase.rosenbrock_minimum, 'abs_tol', 1e-3);
+            testCase.verify_val(cost_val, 0, 'abs_tol', 1e-6);
+        end
+
+        function test_optimise_rosen_lower_bound_minimum_not_accessible(testCase, optimiser)
+            % note intital guess is outside bounds
+            [pars_fit, cost_val, ~] = optimiser([], testCase.rosenbrock, [-1,-1], 'lb', [-inf, 2]);
+            testCase.verify_val(pars_fit, [-1.411, 2], 'abs_tol', 1e-3);
+            testCase.verify_val(cost_val, 5.821, 'abs_tol', 1e-3);
+        end
+
+        function test_optimise_rosen_upper_bound_minimum_accessible(testCase, optimiser)
+            [pars_fit, cost_val, ~] = optimiser([], testCase.rosenbrock, [-1,-1], 'ub', [2, 2]);
+            testCase.verify_val(pars_fit, testCase.rosenbrock_minimum, 'abs_tol', 1e-3);
+            testCase.verify_val(cost_val, 0, 'abs_tol', 1e-6);
+        end
+
+        function test_optimise_rosen_upper_bound_minimum_not_accessible(testCase, optimiser)
+            % note intital guess is outside bounds
+            [pars_fit, cost_val, ~] = optimiser([], testCase.rosenbrock, [-1,-1], 'ub', [0, inf]);
+            testCase.verify_val(pars_fit, [0, 0], 'abs_tol', 1e-3);
+            testCase.verify_val(cost_val, 1, 'abs_tol', 1e-6);
+        end
+
+        function test_optimise_rosen_both_bounds_minimum_accessible(testCase, optimiser)
+            [pars_fit, cost_val, ~] = optimiser([], testCase.rosenbrock, [-1,-1], 'lb', [-2, -2], 'ub', [2, 2]);
+            testCase.verify_val(pars_fit, testCase.rosenbrock_minimum, 'abs_tol', 1e-3);
+            testCase.verify_val(cost_val, 0, 'abs_tol', 1e-6);
+        end
+
+        function test_optimise_rosen_both_bounds_minimum_not_accessible(testCase, optimiser)
+            % note intital guess is outside bounds
+            [pars_fit, cost_val, ~] = optimiser([], testCase.rosenbrock, [-1,-1], 'lb', [-0.5, -0.5], 'ub', [0, 0]);
+            testCase.verify_val(pars_fit, [0, 0], 'abs_tol', 1e-3);
+            testCase.verify_val(cost_val, 1, 'abs_tol', 1e-6);
+        end
+
+    end
+end
+% do parameterised test with all minimisers

--- a/+sw_tests/+unit_tests/unittest_ndbase_optimisers.m
+++ b/+sw_tests/+unit_tests/unittest_ndbase_optimisers.m
@@ -67,6 +67,13 @@ classdef unittest_ndbase_optimisers < sw_tests.unit_tests.unittest_super
             testCase.verify_val(cost_val, 1, 'abs_tol', 1e-6);
         end
 
+        function test_optimise_rosen_parameter_fixed_minimum_not_accessible(testCase, optimiser)
+            % note intital guess is outside bounds
+            [pars_fit, cost_val, ~] = optimiser([], testCase.rosenbrock, [-1,-1], 'lb', [0, -0.5], 'ub', [0, 0]);
+            testCase.verify_val(pars_fit, [0, 0], 'abs_tol', 1e-3);
+            testCase.verify_val(cost_val, 1, 'abs_tol', 1e-6);
+        end
+
     end
 end
 % do parameterised test with all minimisers

--- a/+sw_tests/+unit_tests/unittest_ndbase_optimisers.m
+++ b/+sw_tests/+unit_tests/unittest_ndbase_optimisers.m
@@ -5,19 +5,19 @@ classdef unittest_ndbase_optimisers < sw_tests.unit_tests.unittest_super
     properties
         rosenbrock = @(x) (1-x(1)).^2 + 100*(x(2) - x(1).^2).^2;
         rosenbrock_minimum = [1, 1];
-        poly_func = @(x, p) polyval(p, x)
     end
 
     properties (TestParameter)
         optimiser = {@ndbase.simplex};
+        poly_func = {@(x, p) polyval(p, x), '@(x, p) polyval(p, x)'}
     end
 
     methods (Test)
-        function test_optimise_data_struct(testCase, optimiser)
+        function test_optimise_data_struct(testCase, optimiser, poly_func)
             linear_pars = [2, 1];
             dat = struct('x', 1:3, 'e', ones(1,3));
-            dat.y = testCase.poly_func(dat.x, linear_pars);
-            [pars_fit, cost_val, ~] = optimiser(dat, testCase.poly_func, [-1,-1]);
+            dat.y = polyval(linear_pars, dat.x);
+            [pars_fit, cost_val, ~] = optimiser(dat, poly_func, [-1,-1]);
             testCase.verify_val(pars_fit, linear_pars, 'abs_tol', 1e-3);
             testCase.verify_val(cost_val, 2.5e-7, 'abs_tol', 1e-8);
         end

--- a/+sw_tests/+unit_tests/unittest_ndbase_optimisers.m
+++ b/+sw_tests/+unit_tests/unittest_ndbase_optimisers.m
@@ -74,6 +74,13 @@ classdef unittest_ndbase_optimisers < sw_tests.unit_tests.unittest_super
             testCase.verify_val(cost_val, 1, 'abs_tol', 1e-6);
         end
 
+        function test_optimise_rosen_parameter_all_fixed(testCase, optimiser)
+            % note intital guess is outside bounds
+            [pars_fit, cost_val, ~] = optimiser([], testCase.rosenbrock, [-1,-1], 'lb', [0, 0], 'ub', [0, 0]);
+            testCase.verify_val(pars_fit, [0, 0], 'abs_tol', 1e-3);
+            testCase.verify_val(cost_val, 1, 'abs_tol', 1e-6);
+        end
+
     end
 end
 % do parameterised test with all minimisers

--- a/+sw_tests/+unit_tests/unittest_ndbase_optimisers.m
+++ b/+sw_tests/+unit_tests/unittest_ndbase_optimisers.m
@@ -1,6 +1,6 @@
 classdef unittest_ndbase_optimisers < sw_tests.unit_tests.unittest_super
-    % Runs through unit test for ndbase optimisers, atm only simplex passes
-    % these tests
+    % Runs through unit test for ndbase optimisers using bounded parameter
+    % transformations.
 
     properties
         rosenbrock = @(x) (1-x(1)).^2 + 100*(x(2) - x(1).^2).^2;

--- a/+sw_tests/+unit_tests/unittest_spinw_fitspec.m
+++ b/+sw_tests/+unit_tests/unittest_spinw_fitspec.m
@@ -40,8 +40,8 @@ classdef unittest_spinw_fitspec < sw_tests.unit_tests.unittest_super
     methods (Test)
         function test_fitspec(testCase)
             fitout = testCase.swobj.fitspec(testCase.fitpar);
-            testCase.verify_val(fitout.x, 1.0, 'abs_tol', 0.25);
-            testCase.verify_val(fitout.redX2, 0.0, 'abs_tol', 10);
+            testCase.verify_val(fitout.x, 0.7, 'abs_tol', 0.25);
+            testCase.verify_val(fitout.redX2, 243, 'abs_tol', 10);
         end
         function test_fitspec_twin(testCase)
             % Checks that twins are handled correctly
@@ -50,8 +50,8 @@ classdef unittest_spinw_fitspec < sw_tests.unit_tests.unittest_super
             % If twins not handled correctly, the fit will be bad.
             swobj.addtwin('axis', [1 1 1], 'phid', 54, 'vol', 0.01);
             fitout = swobj.fitspec(testCase.fitpar);
-            testCase.verify_val(fitout.x, 1.0, 'abs_tol', 0.25);
-            testCase.verify_val(fitout.redX2, 0.0, 'abs_tol', 10);
+            testCase.verify_val(fitout.x, 0.7, 'abs_tol', 0.25);
+            testCase.verify_val(fitout.redX2, 243, 'abs_tol', 10);
         end
     end
 end

--- a/.github/workflows/build_pyspinw.yml
+++ b/.github/workflows/build_pyspinw.yml
@@ -161,14 +161,14 @@ jobs:
         run: |
           pip install scipy
           cd ${{ github.workspace }}/python
-          pip install build/*whl
+          pip install wheelhouse/*whl
           cd tests
           python -m unittest
       - name: Create wheel artifact
         uses: actions/upload-artifact@v4
         with:
           name: pySpinW Wheel
-          path: ${{ github.workspace }}/python/build/*.whl        
+          path: ${{ github.workspace }}/python/wheelhouse/*.whl
       - name: Upload release wheels
         if: ${{ github.event_name == 'release' }}
         run: |

--- a/swfiles/+ndbase/cost_function.m
+++ b/swfiles/+ndbase/cost_function.m
@@ -13,16 +13,8 @@ classdef cost_function < handle & matlab.mixin.SetGet
 % 
 % ### Input Arguments
 % 
-% `data`
-% : Either empty or contains data to be fitted stored in a structure with
-%   fields:
-%   * `dat.x`   vector of $N$ independent variables,
-%   * `dat.y`   vector of $N$ data values to be fitted,
-%   * `dat.e`   vector of $N$ standard deviation (positive numbers)
-%               used to weight the fit. If zero or missing
-%               `1/dat.y^2` will be assigned to each point.
-%%`func`
-% : Function handle with one of the following definition:
+% `func`
+% : Function handle or char with one of the following definition:
 %   * `R2 = func(p)`        if `dat` is empty,
 %   * `y  = func(x,p)`      if `dat` is a struct.
 %   Here `x` is a vector of $N$ independent variables, `p` are the
@@ -31,6 +23,17 @@ classdef cost_function < handle & matlab.mixin.SetGet
 %
 % `parameters`
 % :  Vector of doubles
+%
+% ### Name-Value Pair Arguments
+%
+% `data`
+% : Either empty or contains data to be fitted stored in a structure with
+%   fields:
+%   * `dat.x`   vector of $N$ independent variables,
+%   * `dat.y`   vector of $N$ data values to be fitted,
+%   * `dat.e`   vector of $N$ standard deviation (positive numbers)
+%               used to weight the fit. If zero or missing
+%               `1/dat.y^2` will be assigned to each point.
 %
 % `lb`
 % : Optional vector of doubles corresponding to the lower bound of the 

--- a/swfiles/+ndbase/cost_function.m
+++ b/swfiles/+ndbase/cost_function.m
@@ -67,7 +67,7 @@ classdef cost_function < handle & matlab.mixin.SetGet
                 obj.cost_func = fhandle;
             else
                 % fhandle calculates fit/curve function
-                obj.cost_func = @(p) sum(((f(options.data.x(:), p) - options.data.y(:)).^2)./options.data.e(:).^2);
+                obj.cost_func = @(p) sum(((fhandle(options.data.x(:), p) - options.data.y(:)).^2)./options.data.e(:).^2);
             end
             % validate size of bounds
             lb = options.lb;
@@ -125,7 +125,7 @@ classdef cost_function < handle & matlab.mixin.SetGet
             pars_bound = zeros(size(obj.free_to_bound_funcs));
             for ipar_free = 1:numel(pars)
                 ipar_bound = obj.ifree(ipar_free);
-                pars_bound(ipar_bound) = obj.free_to_bound{ipar_bound}(pars(ipar_free));
+                pars_bound(ipar_bound) = obj.free_to_bound_funcs{ipar_bound}(pars(ipar_free));
             end
             % add in fixed parameter values
             pars_bound(obj.ifixed) = obj.pars_fixed;
@@ -134,7 +134,7 @@ classdef cost_function < handle & matlab.mixin.SetGet
         function pars = get_free_parameters(obj, pars_bound)
             pars = zeros(size(pars_bound)); % to preserve par vector shape
             for ipar = obj.ifree
-                pars(ipar) = obj.bound_to_free{ipar}(pars_bound(ipar));
+                pars(ipar) = obj.bound_to_free_funcs{ipar}(pars_bound(ipar));
             end
             pars = pars(obj.ifree);
         end
@@ -177,7 +177,7 @@ classdef cost_function < handle & matlab.mixin.SetGet
             elseif par_bound > ub
                 par_bound = ub;
             end
-            par = arcsin((2*(par_bound - lb)/(ub-lb)) - 1);
+            par = asin((2*(par_bound - lb)/(ub-lb)) - 1);
         end
     end
 end

--- a/swfiles/+ndbase/cost_function.m
+++ b/swfiles/+ndbase/cost_function.m
@@ -56,11 +56,14 @@ classdef cost_function < handle & matlab.mixin.SetGet
     methods
         function obj = cost_function(fhandle, params, options)
             arguments
-                fhandle function_handle
+                fhandle {isFunctionHandleOrChar}
                 params double
                 options.lb double = []
                 options.ub double = []
                 options.data struct = struct()
+            end
+            if ischar(fhandle)
+                fhandle = str2func(fhandle); % convert to fuction handle
             end
             if isempty(fieldnames(options.data))
                 % fhandle calculates cost_val
@@ -69,6 +72,7 @@ classdef cost_function < handle & matlab.mixin.SetGet
                 % fhandle calculates fit/curve function
                 obj.cost_func = @(p) sum(((fhandle(options.data.x(:), p) - options.data.y(:)).^2)./options.data.e(:).^2);
             end
+
             % validate size of bounds
             lb = options.lb;
             ub = options.ub;
@@ -185,4 +189,9 @@ classdef cost_function < handle & matlab.mixin.SetGet
             par = asin((2*(par_bound - lb)/(ub-lb)) - 1);
         end
     end
+end
+
+
+function isFunctionHandleOrChar(func)
+    assert(isa(func, 'function_handle') || ischar(func));
 end

--- a/swfiles/+ndbase/cost_function_wrapper.m
+++ b/swfiles/+ndbase/cost_function_wrapper.m
@@ -40,19 +40,18 @@ classdef cost_function_wrapper < handle & matlab.mixin.SetGet
 %
 % `lb`
 % : Optional vector of doubles corresponding to the lower bound of the 
-%   parameters. Empty vector [] or vector of -inf interpreted as no lower 
-%   bound.
+%   parameters. Empty vector [] or vector of non-finite elements
+%   (e.g. -inf and NaN) are interpreted as no lower bound.
 % 
 % `ub`
 % : Optional vector of doubles corresponding to the upper bound of the 
-%   parameters. Empty vector [] or vector of inf interpreted as no upper 
-%   bound.
+%   parameters. Empty vector [] or vector of non-finite elements
+%   (e.g. inf and NaN) are interpreted as no upper bound.
 %
 % `ifix`
 % : Optional vector of ints corresponding of indices of parameters to fix
 %   (overides bounds if provided)
-%
-% ### Examples
+
     properties (SetObservable)
         % data
         cost_func
@@ -125,8 +124,8 @@ classdef cost_function_wrapper < handle & matlab.mixin.SetGet
             obj.ifixed = [];
             ipars = 1:numel(pars); % used later
             for ipar = ipars
-                has_lb = ~isempty(lb) && lb(ipar) > -inf;
-                has_ub = ~isempty(ub) && ub(ipar) < inf;
+                has_lb = ~isempty(lb) && isfinite(lb(ipar));
+                has_ub = ~isempty(ub) && isfinite(ub(ipar));
                 is_fixed = any(uint8(ifix) == ipar);
                 if has_lb && has_ub
                     % both bounds specified and parameter not fixed

--- a/swfiles/+ndbase/cost_function_wrapper.m
+++ b/swfiles/+ndbase/cost_function_wrapper.m
@@ -59,6 +59,10 @@ classdef cost_function_wrapper < handle & matlab.mixin.SetGet
         pars_fixed
     end
 
+    properties (Constant)
+       fix_tol = 1e-10
+    end
+
     methods
         function obj = cost_function_wrapper(fhandle, params, options)
             arguments
@@ -123,7 +127,7 @@ classdef cost_function_wrapper < handle & matlab.mixin.SetGet
                     obj.free_to_bound_funcs{ipar} = @(p) obj.free_to_bound_has_lb_and_ub(p, lb(ipar), ub(ipar));
                     obj.bound_to_free_funcs{ipar} = @(p) obj.bound_to_free_has_lb_and_ub(p, lb(ipar), ub(ipar));
                     % check if fixed
-                    if abs(ub(ipar) - lb(ipar)) < max(abs(ub(ipar)), 1)*1e-10
+                    if abs(ub(ipar) - lb(ipar)) < max(abs(ub(ipar)), 1)*obj.fix_tol
                         obj.ifixed = [obj.ifixed, ipar];
                         if  pars(ipar) < lb(ipar)
                              pars(ipar) = lb(ipar);

--- a/swfiles/+ndbase/cost_function_wrapper.m
+++ b/swfiles/+ndbase/cost_function_wrapper.m
@@ -9,7 +9,10 @@ classdef cost_function_wrapper < handle & matlab.mixin.SetGet
 % Optionally the parameters can be bound in which case the class will
 % perform a transformation to convert the constrained optimization problem
 % into an un-constrained problem, using the formulation devised
-% (and documented) for MINUIT (and also used in lmfit).
+% (and documented) for MINUIT [1] and also used in lmfit [2].
+%
+% [1] https://root.cern/root/htmldoc/guides/minuit2/Minuit2.pdf#section.2.3
+% [2] https://lmfit.github.io/lmfit-py/bounds.html
 % 
 % ### Input Arguments
 % 
@@ -103,6 +106,11 @@ classdef cost_function_wrapper < handle & matlab.mixin.SetGet
         end
 
         function init_bound_parameter_transforms(obj, pars, lb, ub)
+            % Note free parameters to be used externally in the
+            % optimisation (note in lmfit [2] pfree is called p_internal).
+            % Bound parameters are the original parameters
+            % pass into the constructor (that may or may not be bound or
+            % fixed).
             obj.free_to_bound_funcs = cell(size(pars));
             obj.bound_to_free_funcs = cell(size(pars));
             obj.ifixed = [];

--- a/swfiles/+ndbase/cost_function_wrapper.m
+++ b/swfiles/+ndbase/cost_function_wrapper.m
@@ -1,4 +1,4 @@
-classdef cost_function < handle & matlab.mixin.SetGet
+classdef cost_function_wrapper < handle & matlab.mixin.SetGet
 % ### Syntax
 % 
 % `param = fit_parameter(value, lb, ub)`
@@ -57,7 +57,7 @@ classdef cost_function < handle & matlab.mixin.SetGet
     end
 
     methods
-        function obj = cost_function(fhandle, params, options)
+        function obj = cost_function_wrapper(fhandle, params, options)
             arguments
                 fhandle {isFunctionHandleOrChar}
                 params double

--- a/swfiles/+ndbase/cost_function_wrapper.m
+++ b/swfiles/+ndbase/cost_function_wrapper.m
@@ -141,9 +141,6 @@ classdef cost_function_wrapper < handle & matlab.mixin.SetGet
                 elseif has_ub
                     obj.free_to_bound_funcs{ipar} = @(p) obj.free_to_bound_has_ub(p, ub(ipar));
                     obj.bound_to_free_funcs{ipar} = @(p) obj.bound_to_free_has_ub(p, ub(ipar));
-                else
-                    obj.free_to_bound_funcs{ipar} = @(p) p;
-                    obj.bound_to_free_funcs{ipar} = @(p) p;
                 end
                 % check fixed parameters
                 if is_fixed
@@ -166,7 +163,11 @@ classdef cost_function_wrapper < handle & matlab.mixin.SetGet
             pars_bound = zeros(size(obj.free_to_bound_funcs));
             for ipar_free = 1:numel(pars)
                 ipar_bound = obj.ifree(ipar_free);
-                pars_bound(ipar_bound) = obj.free_to_bound_funcs{ipar_bound}(pars(ipar_free));
+                if isempty(obj.free_to_bound_funcs{ipar_bound})
+                    pars_bound(ipar_bound) = pars(ipar_free); % no bounds
+                else
+                    pars_bound(ipar_bound) = obj.free_to_bound_funcs{ipar_bound}(pars(ipar_free));
+                end
             end
             % add in fixed parameter values
             pars_bound(obj.ifixed) = obj.pars_fixed;
@@ -175,7 +176,11 @@ classdef cost_function_wrapper < handle & matlab.mixin.SetGet
         function pars = get_free_parameters(obj, pars_bound)
             pars = zeros(size(pars_bound)); % to preserve par vector shape
             for ipar = obj.ifree
-                pars(ipar) = obj.bound_to_free_funcs{ipar}(pars_bound(ipar));
+                if isempty(obj.bound_to_free_funcs{ipar})
+                    pars(ipar) = pars_bound(ipar);
+                else
+                    pars(ipar) = obj.bound_to_free_funcs{ipar}(pars_bound(ipar));
+                end
             end
             pars = pars(obj.ifree);
         end

--- a/swfiles/+ndbase/simplex.m
+++ b/swfiles/+ndbase/simplex.m
@@ -153,21 +153,6 @@ inpForm.soft   = {false     false    false  false     true      true    };
 param = sw_readparam(inpForm, varargin{:});
 param.Np = Np;
 
-% limits
-LB = param.lb;
-UB = param.ub;
-
-if ~isempty(LB) && ~isempty(UB) && any(UB<LB)
-    error('simplex:WrongInput','Upper boundary has to be larger than the lower boundary!');
-end
-
-% number of free parameters
-if isempty(LB) || isempty(UB)
-    Nv = max(numel(LB),numel(UB));
-else
-    Nv = sum(UB>LB);
-end
-
 % check input function
 if ischar(func)
     % convert to fuction handle
@@ -178,126 +163,18 @@ if ~isa(func,'function_handle')
     error('simplex:WrongInput','The input function is neither a string, not function handle!');
 end
 
-% define weighted least squares if dat is given
-if ~isempty(dat)
-    dat.x = dat.x(:);
-    dat.y = dat.y(:);
-    
-    if ~isfield(dat,'e') || isempty(dat.e) || ~any(dat.e(:))
-        weight = 1./abs(dat.y);
-    else
-        if any(dat.e(:)<0)
-            error('pso:WrongInput','Standard deviations have to be positive!')
-        end
-        weight = 1./dat.e(:).^2;
-    end
-    func0 = func;
-    func = @(p)sum(weight.*(func(dat.x(:),p)-dat.y(:)).^2);
-end
+cost_func = ndbase.cost_function(func, p0, "data", dat, 'lb', param.lb, 'ub', param.ub);
 
-if isempty(LB)
-  LB = repmat(-inf,Np,1);
-else
-  LB = LB(:);
-end
-if (nargin<4) || isempty(UB)
-  UB = inf(Np,1);
-else
-  UB = UB(:);
-end
-
-if (Np~=numel(LB)) || (Np~=numel(UB))
-  error('simplex:WrongInput','p0 is incompatible in size with the given limits!')
-end
-
-
-% 0 --> unconstrained variable
-% 1 --> lower bound only
-% 2 --> upper bound only
-% 3 --> dual finite bounds
-% 4 --> fixed variable
-param.BoundClass = zeros(Np,1);
-for ii=1:Np
-  k = isfinite(LB(ii)) + 2*isfinite(UB(ii));
-  param.BoundClass(ii) = k;
-  if (k==3) && (LB(ii)==UB(ii))
-    param.BoundClass(ii) = 4;
-  end
-end
-
-% transform starting values into their unconstrained
-% surrogates. Check for infeasible starting guesses.
-p0u = p0;
-k   = 1;
-for ii = 1:Np
-  switch param.BoundClass(ii)
-    case 1
-      % lower bound only
-      if p0(ii)<=LB(ii)
-        % infeasible starting value. Use bound.
-        p0u(k) = 0;
-      else
-        p0u(k) = sqrt(p0(ii) - LB(ii));
-      end
-      
-      % increment k
-      k=k+1;
-    case 2
-      % upper bound only
-      if p0(ii)>=UB(ii)
-        % infeasible starting value. use bound.
-        p0u(k) = 0;
-      else
-        p0u(k) = sqrt(UB(ii) - p0(ii));
-      end
-      
-      % increment k
-      k=k+1;
-    case 3
-      % lower and upper bounds
-      if p0(ii)<=LB(ii)
-        % infeasible starting value
-        p0u(k) = -pi/2;
-      elseif p0(ii)>=UB(ii)
-        % infeasible starting value
-        p0u(k) = pi/2;
-      else
-        p0u(k) = 2*(p0(ii) - LB(ii))/(UB(ii)-LB(ii)) - 1;
-        % shift by 2*pi to avoid problems at zero in fminsearch
-        % otherwise, the initial simplex is vanishingly small
-        p0u(k) = 2*pi+asin(max(-1,min(1,p0u(k))));
-      end
-      
-      % increment k
-      k=k+1;
-    case 0
-      % unconstrained variable. x0u(i) is set.
-      p0u(k) = p0(ii);
-      
-      % increment k
-      k=k+1;
-    case 4
-      % fixed variable. drop it before fminsearch sees it.
-      % k is not incremented for this variable.
-  end
-  
-end
-% if any of the unknowns were fixed, then we need to shorten
-% x0u now.
-if k<=Np
-  p0u(k:Np) = [];
-end
+% transform starting values into their unconstrained surrogates.
+p0u = cost_func.get_free_parameters(p0);
 
 % were all the variables fixed?
 if isempty(p0u)
   % All variables were fixed. quit immediately, setting the
   % appropriate parameters, then return.
   
-  % undo the variable transformations into the original space
-  x = xtransform(p0u,param);
-  
   % stuff fval with the final value
-  fVal = func(x,p0);
+  fVal = cost_function.eval_cost_function(p0u);
   
   stat            = struct;
   stat.msg        = 'Parameters are fixed, no optimisation';
@@ -312,25 +189,17 @@ if isempty(p0u)
   stat.algorithm  = 'Nelder-Mead simplex direct search';
   stat.exitFlag   = 0;
   stat.param = param;
-  
-  if isempty(dat)
-      stat.func   = func;
-  else
-      stat.func   = func0;
-  end
+  stat.func = cost_func.cost_func;
   % return with no call at all to fminsearch
   return
 end
 
 
-% now we can call fminsearch, but with our own
-% intra-objective function.
-intrafun = @(x)func(xtransform(x,param));
-
-[pu,fVal,exitFlag,stat0] = fminsearch(intrafun,p0u,param);
+% now we can call fminsearch, but with our own free parameter
+[pu,fVal,exitFlag,stat0] = fminsearch(@cost_func.eval_cost_function, p0u, param);
 
 % undo the variable transformations into the original space
-pOpt = xtransform(pu,param);
+pOpt = cost_func.get_bound_parameters(pu);
 
 stat            = struct;
 stat.p          = pOpt;
@@ -339,7 +208,7 @@ if isempty(dat)
     stat.redX2 = fVal;
 else
     % divide R2 with the statistical degrees of freedom
-    stat.redX2   = fVal/(numel(dat.x)-Nv+1);
+    stat.redX2   = fVal/(numel(dat.x)-cost_func.get_num_free_parameters()+1);
 end
 stat.msg        = stat0.message;
 stat.Rsq        = [];
@@ -352,51 +221,7 @@ stat.algorithm  = stat0.algorithm;
 stat.exitFlag   = exitFlag;
 stat.param = param;
 
-if isempty(dat)
-    stat.func   = func;
-else
-    stat.func   = func0;
-end
+stat.func = cost_func.cost_func;
 
 end % mainline end
 
-% ======================================
-function xtrans = xtransform(x,p)
-% converts unconstrained variables into their original domains
-
-xtrans = x*0;
-% k allows some variables to be fixed, thus dropped from the
-% optimization.
-k=1;
-for i = 1:p.Np
-  switch p.BoundClass(i)
-    case 1
-      % lower bound only
-      xtrans(i) = p.lb(i) + x(k).^2;
-      
-      k=k+1;
-    case 2
-      % upper bound only
-      xtrans(i) = p.ub(i) - x(k).^2;
-      
-      k=k+1;
-    case 3
-      % lower and upper bounds
-      xtrans(i) = (sin(x(k))+1)/2;
-      xtrans(i) = xtrans(i)*(p.ub(i) - p.lb(i)) + p.lb(i);
-      % just in case of any floating point problems
-      xtrans(i) = max(p.lb(i),min(p.ub(i),xtrans(i)));
-      
-      k=k+1;
-    case 4
-      % fixed variable, bounds are equal, set it at either bound
-      xtrans(i) = p.lb(i);
-    case 0
-      % unconstrained variable.
-      xtrans(i) = x(k);
-      
-      k=k+1;
-  end
-end
-
-end % sub function xtransform end

--- a/swfiles/+ndbase/simplex.m
+++ b/swfiles/+ndbase/simplex.m
@@ -152,25 +152,25 @@ function [pOpt,fVal,stat] = simplex(dat,func,p0,varargin)
     
     param = sw_readparam(inpForm, varargin{:});
   
-    cost_func = ndbase.cost_function(func, p0, "data", dat, 'lb', param.lb, 'ub', param.ub);
+    cost_func_wrap = ndbase.cost_function_wrapper(func, p0, "data", dat, 'lb', param.lb, 'ub', param.ub);
     
     % transform starting values into their unconstrained surrogates.
-    p0_free = cost_func.get_free_parameters(p0);
+    p0_free = cost_func_wrap.get_free_parameters(p0);
     
     if isempty(p0_free)
         % All parameters fixed, evaluate cost at initial guess
         % don't use p0 as could contain fixed params outside bounds
-        pOpt = cost_func.get_bound_parameters(p0_free);
-        fVal = cost_func.eval_cost_function(p0_free);
+        pOpt = cost_func_wrap.get_bound_parameters(p0_free);
+        fVal = cost_func_wrap.eval_cost_function(p0_free);
         fit_stat.message        = 'Parameters are fixed, no optimisation';
         fit_stat.iterations = 0;
         fit_stat.funcCount  = 1;
         exitFlag = 0;
     else
         % now we can call fminsearch, but with our own free parameter
-        [p_free, fVal, exitFlag, fit_stat] = fminsearch(@cost_func.eval_cost_function, p0_free, param);
+        [p_free, fVal, exitFlag, fit_stat] = fminsearch(@cost_func_wrap.eval_cost_function, p0_free, param);
         % undo the variable transformations into the original space
-        pOpt = cost_func.get_bound_parameters(p_free);
+        pOpt = cost_func_wrap.get_bound_parameters(p_free);
     end
 
     % setup output struct
@@ -180,9 +180,9 @@ function [pOpt,fVal,stat] = simplex(dat,func,p0,varargin)
     stat.corrP      = [];
     stat.cvgHst     = [];
     stat.algorithm  = 'Nelder-Mead simplex direct search';
-    stat.func = cost_func.cost_func;
+    stat.func = cost_func_wrap.cost_func;
     stat.param = param;
-    stat.param.Np = cost_func.get_num_free_parameters();
+    stat.param.Np = cost_func_wrap.get_num_free_parameters();
     stat.msg        = fit_stat.message;
     stat.iterations = fit_stat.iterations;
     stat.funcCount  = fit_stat.funcCount;

--- a/swfiles/+ndbase/simplex.m
+++ b/swfiles/+ndbase/simplex.m
@@ -162,7 +162,7 @@ function [pOpt,fVal,stat] = simplex(dat,func,p0,varargin)
         % don't use p0 as could contain fixed params outside bounds
         pOpt = cost_func_wrap.get_bound_parameters(p0_free);
         fVal = cost_func_wrap.eval_cost_function(p0_free);
-        fit_stat.message        = 'Parameters are fixed, no optimisation';
+        fit_stat.message = 'Parameters are fixed, no optimisation';
         fit_stat.iterations = 0;
         fit_stat.funcCount  = 1;
         exitFlag = 0;

--- a/swfiles/+ndbase/simplex.m
+++ b/swfiles/+ndbase/simplex.m
@@ -151,17 +151,7 @@ function [pOpt,fVal,stat] = simplex(dat,func,p0,varargin)
     inpForm.soft   = {false     false    false  false     true      true    };
     
     param = sw_readparam(inpForm, varargin{:});
-
-    % check input function
-    if ischar(func)
-        % convert to fuction handle
-        func = str2func(func);
-    end
-    
-    if ~isa(func,'function_handle')
-        error('simplex:WrongInput','The input function is neither a string, not function handle!');
-    end
-    
+  
     cost_func = ndbase.cost_function(func, p0, "data", dat, 'lb', param.lb, 'ub', param.ub);
     
     % transform starting values into their unconstrained surrogates.


### PR DESCRIPTION
Refactor simplex to use wrapper class `ndbase.cost_function_wrapper` handling bound and fixed parameters.
Bound parameters are transformed using the formulation in MINUIT, as documented in lmfit 
https://lmfit.github.io/lmfit-py/bounds.html
The wrapper class works by storing the fixed parameters (if any) and returning all non-fixed (potentially transformed) parameters  that are used to evaluate the cost function so that an unconstrained minimisation can be performed (the fixed parameters are used internally when evaluating the cost function, but are not seen by the minimiser).

Have also added unit tests for wrapper class and simplex minimiser. The latter unit tests can be applied for any `ndbase` minimiser - however none of the other current minimisers succeed in optimizing the problems in the test file.
- The `lm', `lm2` and `lm3` minimisers to not converge on the minimum (there's only one minimum in the cost function surface)
- The `pso` minimiser is not suited to unconstrained minimisation (generates initial particle swarm locations based on bounds - the default bounds if none are provided are huge and don't depend on the scale of the input parameters).

Because the `lm` minimisers have been observed to perform poorly it has been decided to re-write them from scratch in a separate PR (after which hopefully they can share the same unit test as `simplex`)
