### PR TITLE
More usability improvements sw fitpowder

### DIFF
--- a/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
+++ b/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
@@ -406,11 +406,12 @@ classdef unittest_sw_fitpowder < sw_tests.unit_tests.unittest_super
         function test_estimate_scale_factor(testCase)
             out = sw_fitpowder(testCase.swobj, testCase.data_2d, ...
                                testCase.fit_func, testCase.j1);
+            out.set_bg_parameters(3, 0.05);  % set constant bg
             out.powspec_args.dE = 0.1;  % constant energy resolution
             out.powspec_args.hermit = true;
             out.estimate_scale_factor()
             expected_fitpow = testCase.default_fitpow;
-            expected_fitpow.params(end) = 17.6;
+            expected_fitpow.params(end) = 17.36;
             testCase.verify_results(out, expected_fitpow, ...
                                     testCase.default_fields, 'abs_tol', 1e-1);
         end

--- a/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
+++ b/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
@@ -466,6 +466,28 @@ classdef unittest_sw_fitpowder < sw_tests.unit_tests.unittest_super
             expected_fitpow.modQ_cens = testCase.default_modQ_cens_1d; % integrtate over nQ pts
             testCase.verify_results(out, expected_fitpow);
         end
+
+        function test_set_bg_region_data_2d(testCase)
+            out = sw_fitpowder(testCase.swobj, testCase.data_2d, ...
+                               testCase.fit_func, testCase.j1);
+            out.set_bg_region(0,1.5); % for all Q
+            out.set_bg_region(2.5,3.5,4.5,inf); % for highest Q
+            expected_fitpow = testCase.default_fitpow;
+            expected_fitpow.ibg = [1;4;6];
+            testCase.verify_results(out, expected_fitpow);
+        end
+
+        function test_set_bg_region_data_1d(testCase)
+            out = sw_fitpowder(testCase.swobj, testCase.data_1d_cuts, ...
+                               testCase.fit_func, testCase.j1);
+            expected_fitpow = testCase.default_fitpow;
+            expected_fitpow.modQ_cens = testCase.default_modQ_cens_1d;
+            out.set_bg_region(0,1.5); % for all cuts
+            out.set_bg_region(2.5,3.5,2); % for last cut
+            expected_fitpow.ibg = [1;4;6];
+            testCase.verify_results(out, expected_fitpow);
+        end
+
     end
 
 end

--- a/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
+++ b/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
@@ -611,6 +611,17 @@ classdef unittest_sw_fitpowder < sw_tests.unit_tests.unittest_super
             testCase.verify_val(data, testCase.data_2d);
         end
 
+        function test_export_data_2d_with_filename(testCase)
+            import matlab.unittest.fixtures.TemporaryFolderFixture
+            fixture = testCase.applyFixture(TemporaryFolderFixture);
+            tmp_file = fullfile(fixture.Folder,"data.mat");
+            out = sw_fitpowder(testCase.swobj, testCase.data_2d, ...
+                               testCase.fit_func, testCase.j1);
+            data = out.export_data(tmp_file);
+            testCase.verify_val(data, testCase.data_2d);
+            testCase.assertTrue(isfile(tmp_file));
+        end
+
         function test_export_data_1d(testCase)
             out = sw_fitpowder(testCase.swobj, testCase.data_1d_cuts, ...
                                testCase.fit_func, testCase.j1);

--- a/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
+++ b/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
@@ -605,7 +605,7 @@ classdef unittest_sw_fitpowder < sw_tests.unit_tests.unittest_super
             out.set_bg_parameters("Q1", -5);
             out.set_bg_parameters("E1", 5);
             expected_fitpow = testCase.default_fitpow;
-            expected_fitpow.params(2:4) = [5, 0, -5]; % E1, E0, Q1
+            expected_fitpow.params(2:4) = [-5, 5,0]; % Q1, E1, E0
             testCase.verify_results(out, expected_fitpow);
         end
 
@@ -634,7 +634,7 @@ classdef unittest_sw_fitpowder < sw_tests.unit_tests.unittest_super
             out = sw_fitpowder(testCase.swobj, testCase.data_2d, ...
                                testCase.fit_func, testCase.j1);
             bg_pars = 1:3;
-            bg_labels = ["E1","E0","Q1"];
+            bg_labels = ["Q1","E1","E0"];
             out.set_bg_parameters(bg_labels, bg_pars);
             out.fix_bg_parameters(bg_labels);
             expected_fitpow = testCase.default_fitpow;

--- a/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
+++ b/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
@@ -585,6 +585,21 @@ classdef unittest_sw_fitpowder < sw_tests.unit_tests.unittest_super
             testCase.verify_results(out, expected_fitpow);
         end
 
+        function test_export_data_2d(testCase)
+            out = sw_fitpowder(testCase.swobj, testCase.data_2d, ...
+                               testCase.fit_func, testCase.j1);
+            data = out.export_data();
+            testCase.verify_val(data, testCase.data_2d);
+        end
+
+        function test_export_data_1d(testCase)
+            out = sw_fitpowder(testCase.swobj, testCase.data_1d_cuts, ...
+                               testCase.fit_func, testCase.j1);
+            data = out.export_data();
+            testCase.verify_val(data, testCase.data_1d_cuts);
+        end
+
+
     end
 
 end

--- a/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
+++ b/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
@@ -76,13 +76,41 @@ classdef unittest_sw_fitpowder < sw_tests.unit_tests.unittest_super
             testCase.verify_results(out, expected_fitpow);
         end
 
-        function test_set_background_strategy(testCase)
+        function test_set_background_strategy_to_planar(testCase)
             out = sw_fitpowder(testCase.swobj, testCase.data_1d_cuts, ...
                                testCase.fit_func, testCase.j1, "independent");
+            % set some background parameters (correpsonding to planar bg
+            % with slope_en=slope_q=intercept =2
+            out.set_bg_parameters(1, 2); % en_slope = 2
+            out.set_bg_parameters(2, 10, 1); % intercept = 10 for cut 1
+            out.set_bg_parameters(2, 12, 2); % intercept = 12 for cut 2
             out.set_background_strategy("planar");
             expected_fitpow = testCase.default_fitpow;
+            expected_fitpow.params(2:end-1) = 2;
             expected_fitpow.modQ_cens = testCase.default_modQ_cens_1d;
-            testCase.verify_results(out, expected_fitpow);
+            testCase.verify_results(out, expected_fitpow, ...
+                                    testCase.default_fields, ...
+                                    'abs_tol', 1e-10);
+        end
+
+        function test_set_background_strategy_to_indep(testCase)
+            out = sw_fitpowder(testCase.swobj, testCase.data_1d_cuts, ...
+                               testCase.fit_func, testCase.j1, "planar");
+            % set some background parameters (correpsonding to planar bg
+            % with slope_en=slope_q=intercept =2
+            out.set_bg_parameters(1:3, [2,2,2]); % en_slope = 2
+            out.set_background_strategy("independent");
+            expected_fitpow = testCase.default_fitpow;
+            % add extra background param
+            expected_fitpow.params = expected_fitpow.params([1:2,2:end],:);
+            expected_fitpow.bounds = expected_fitpow.bounds([1:2,2:end],:);
+            expected_fitpow.params(2:2:end-1) = 2; % en slope
+            expected_fitpow.params(3) = 10; % intercept = 10 for cut 1
+            expected_fitpow.params(5) = 12; % intercept = 12 for cut 2
+            expected_fitpow.modQ_cens = testCase.default_modQ_cens_1d;
+            testCase.verify_results(out, expected_fitpow, ...
+                                    testCase.default_fields, ...
+                                    'abs_tol', 1e-10);
         end
 
         function test_replace_2D_data_with_1D_cuts(testCase)

--- a/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
+++ b/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
@@ -342,6 +342,21 @@ classdef unittest_sw_fitpowder < sw_tests.unit_tests.unittest_super
                                     'abs_tol', 1e-4);
         end
 
+        function test_fit_background_and_scale(testCase)
+            out = sw_fitpowder(testCase.swobj, testCase.data_2d, ...
+                               testCase.fit_func, testCase.j1);
+            out.fix_bg_parameters(1:2); % fix slopes of background to 0
+            out.set_bg_parameters(3, 1.5); % initial guess
+            out.fit_background_and_scale();
+            expected_fitpow = testCase.default_fitpow;
+            expected_fitpow.params(end-1) = 0.0029;
+            expected_fitpow.params(end) = 15.47;
+            expected_fitpow.bounds(2:3,:) = 0; % fixed bg slopes
+            testCase.verify_results(out, expected_fitpow, ...
+                                    testCase.default_fields, ...
+                                    'abs_tol', 1e-3);
+        end
+
         function test_calc_cost_func_of_background_indep(testCase)
             out = sw_fitpowder(testCase.swobj, testCase.data_1d_cuts, ...
                                testCase.fit_func, testCase.j1, "independent", 2);

--- a/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
+++ b/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
@@ -406,7 +406,7 @@ classdef unittest_sw_fitpowder < sw_tests.unit_tests.unittest_super
             bg_pars(end) = 1;
             out.estimate_constant_background(); % so ibg is set
             cost = out.calc_cost_func_of_background(bg_pars);
-            testCase.verify_val(cost, 5);
+            testCase.verify_val(cost, 10);
         end
 
         function test_set_errors_of_bg_bins(testCase)

--- a/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
+++ b/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
@@ -82,13 +82,13 @@ classdef unittest_sw_fitpowder < sw_tests.unit_tests.unittest_super
             out = sw_fitpowder(testCase.swobj, testCase.data_1d_cuts, ...
                                testCase.fit_func, testCase.j1, "independent");
             % set some background parameters (correpsonding to planar bg
-            % with slope_en=slope_q=intercept =2
-            out.set_bg_parameters(1, 2); % en_slope = 2
-            out.set_bg_parameters(2, 10, 1); % intercept = 10 for cut 1
-            out.set_bg_parameters(2, 12, 2); % intercept = 12 for cut 2
+            % with slope_en=1, slope_q=2, intercept = 3
+            out.set_bg_parameters(1, 1); % en_slope = 1
+            out.set_bg_parameters(2, 11, 1); % intercept = 4*2 + 3 for cut 1 
+            out.set_bg_parameters(2, 13, 2); % intercept = 5*2 + 3 for cut 2
             out.set_background_strategy("planar");
             expected_fitpow = testCase.default_fitpow;
-            expected_fitpow.params(2:end-1) = 2;
+            expected_fitpow.params(2:end-1) = [2,1,3];
             expected_fitpow.modQ_cens = testCase.default_modQ_cens_1d;
             testCase.verify_results(out, expected_fitpow, ...
                                     testCase.default_fields, ...
@@ -99,16 +99,16 @@ classdef unittest_sw_fitpowder < sw_tests.unit_tests.unittest_super
             out = sw_fitpowder(testCase.swobj, testCase.data_1d_cuts, ...
                                testCase.fit_func, testCase.j1, "planar");
             % set some background parameters (correpsonding to planar bg
-            % with slope_en=slope_q=intercept =2
-            out.set_bg_parameters(1:3, [2,2,2]); % en_slope = 2
+            % with slope_en=1, slope_q=2, intercept = 3
+            out.set_bg_parameters(1:3, [2,1,3]); % en_slope = 2
             out.set_background_strategy("independent");
             expected_fitpow = testCase.default_fitpow;
             % add extra background param
             expected_fitpow.params = expected_fitpow.params([1:2,2:end],:);
             expected_fitpow.bounds = expected_fitpow.bounds([1:2,2:end],:);
-            expected_fitpow.params(2:2:end-1) = 2; % en slope
-            expected_fitpow.params(3) = 10; % intercept = 10 for cut 1
-            expected_fitpow.params(5) = 12; % intercept = 12 for cut 2
+            expected_fitpow.params(2:2:end-1) = 1; % en slope
+            expected_fitpow.params(3) = 11; % intercept = 10 for cut 1
+            expected_fitpow.params(5) = 13; % intercept = 12 for cut 2
             expected_fitpow.modQ_cens = testCase.default_modQ_cens_1d;
             testCase.verify_results(out, expected_fitpow, ...
                                     testCase.default_fields, ...

--- a/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
+++ b/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
@@ -121,7 +121,7 @@ classdef unittest_sw_fitpowder < sw_tests.unit_tests.unittest_super
             qcens = [4, 5];
             out.replace_2D_data_with_1D_cuts(qcens-0.5, qcens+0.5)
             expected_fitpow = testCase.default_fitpow;
-            expected_fitpow.modQ_cens = testCase.default_modQ_cens_1d;
+            expected_fitpow.modQ_cens = qcens;
             testCase.verify_results(out, expected_fitpow);
         end
 
@@ -132,7 +132,7 @@ classdef unittest_sw_fitpowder < sw_tests.unit_tests.unittest_super
             out.replace_2D_data_with_1D_cuts(qcens-0.5, qcens+0.5,...
                                              "independent")
             expected_fitpow = testCase.default_fitpow;
-            expected_fitpow.modQ_cens = testCase.default_modQ_cens_1d;
+            expected_fitpow.modQ_cens = qcens;  % not nQ values as using bins in 2D data
             % add extra background param
             expected_fitpow.params = expected_fitpow.params([1:2,2:end],:);
             expected_fitpow.bounds = expected_fitpow.bounds([1:2,2:end],:);
@@ -406,7 +406,7 @@ classdef unittest_sw_fitpowder < sw_tests.unit_tests.unittest_super
             bg_pars(end) = 1;
             out.estimate_constant_background(); % so ibg is set
             cost = out.calc_cost_func_of_background(bg_pars);
-            testCase.verify_val(cost, 10);
+            testCase.verify_val(cost, 5);
         end
 
         function test_set_errors_of_bg_bins(testCase)

--- a/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
+++ b/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
@@ -672,6 +672,14 @@ classdef unittest_sw_fitpowder < sw_tests.unit_tests.unittest_super
             testCase.verify_results(out, expected_fitpow);
         end
 
+        function test_add_1Dcuts_withs_qs_specified(testCase)
+            cuts = arrayfun(@(qs) struct('x', 1:3, 'y', 1:3, 'e', 1:3, 'qs', qs), ...
+                            4:5);
+            out = sw_fitpowder(testCase.swobj, cuts, ...
+                               testCase.fit_func, testCase.j1);
+            testCase.verify_results(out, testCase.default_fitpow);
+        end
+
     end
 
 end

--- a/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
+++ b/+sw_tests/+unit_tests/unittest_sw_fitpowder.m
@@ -81,7 +81,7 @@ classdef unittest_sw_fitpowder < sw_tests.unit_tests.unittest_super
         function test_set_background_strategy_to_planar(testCase)
             out = sw_fitpowder(testCase.swobj, testCase.data_1d_cuts, ...
                                testCase.fit_func, testCase.j1, "independent");
-            % set some background parameters (correpsonding to planar bg
+            % set some background parameters for 1D cuts equivalent to a planar bg
             % with slope_en=1, slope_q=2, intercept = 3
             out.set_bg_parameters(1, 1); % en_slope = 1
             out.set_bg_parameters(2, 11, 1); % intercept = 4*2 + 3 for cut 1 
@@ -177,6 +177,25 @@ classdef unittest_sw_fitpowder < sw_tests.unit_tests.unittest_super
                                testCase.fit_func, testCase.j1);
             bg_pars = [-5, 5];
             out.set_bg_parameters(1:2, bg_pars);
+            expected_fitpow = testCase.default_fitpow;
+            expected_fitpow.params(2:3) = bg_pars;
+            testCase.verify_results(out, expected_fitpow);
+        end
+
+        function test_set_bg_parameters_with_char(testCase)
+            out = sw_fitpowder(testCase.swobj, testCase.data_2d, ...
+                               testCase.fit_func, testCase.j1);
+            out.set_bg_parameters('E0', -5);
+            expected_fitpow = testCase.default_fitpow;
+            expected_fitpow.params(end-1) = -5;
+            testCase.verify_results(out, expected_fitpow);
+        end
+
+        function test_set_bg_parameters_with_cell_of_char(testCase)
+            out = sw_fitpowder(testCase.swobj, testCase.data_2d, ...
+                               testCase.fit_func, testCase.j1);
+            bg_pars = [-5, 5];
+            out.set_bg_parameters({'Q1', 'E1'}, bg_pars);
             expected_fitpow = testCase.default_fitpow;
             expected_fitpow.params(2:3) = bg_pars;
             testCase.verify_results(out, expected_fitpow);
@@ -621,8 +640,7 @@ classdef unittest_sw_fitpowder < sw_tests.unit_tests.unittest_super
             out = sw_fitpowder(testCase.swobj, testCase.data_1d_cuts, ...
                                testCase.fit_func, testCase.j1, "independent", 1);
             bg_pars = [-5, 5];
-            out.set_bg_parameters("E1", bg_pars(1));
-            out.set_bg_parameters("E0", bg_pars(2));
+            out.set_bg_parameters(["E1", "E0"], bg_pars);
             expected_fitpow = testCase.default_fitpow;
             expected_fitpow.params = [expected_fitpow.params(1);
                                       bg_pars(:); bg_pars(:); 1];
@@ -642,6 +660,7 @@ classdef unittest_sw_fitpowder < sw_tests.unit_tests.unittest_super
             expected_fitpow.bounds(2:4, :) = repmat(bg_pars(:), 1,2);
             testCase.verify_results(out, expected_fitpow);
         end
+
     end
 
 end

--- a/swfiles/+ndbase/lm4.m
+++ b/swfiles/+ndbase/lm4.m
@@ -223,14 +223,14 @@ else
     end
     % collect output
     pOpt = cost_func_wrap.get_bound_parameters(p);
+    perr = zeros(size(pOpt));
     fVal = cost_val / ndof;
     if exit_flag > 0
         % converged on solution - calculate errors
         cov = pinv(hess) * 2.0 * fVal;
-        perr = sqrt(diag(cov));
+        perr(cost_func_wrap.ifree) = sqrt(diag(cov));
     else
         message = "Failed to converge in MaxIter";
-        perr = zeros(size(pOpt));
     end
 end
 

--- a/swfiles/+ndbase/lm4.m
+++ b/swfiles/+ndbase/lm4.m
@@ -227,7 +227,7 @@ else
     fVal = cost_val / ndof;
     if exit_flag > 0
         % converged on solution - calculate errors
-        cov = pinv(hess) * 2.0 * fVal;
+        cov = pinv(hess) * 2.0;
         perr(cost_func_wrap.ifree) = sqrt(diag(cov));
     else
         message = "Failed to converge in MaxIter";

--- a/swfiles/sw_fitpowder.m
+++ b/swfiles/sw_fitpowder.m
@@ -876,7 +876,10 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
 
 
         function modQ_cens = get_modQ_cens_of_cuts(obj)
-            modQ_cens = mean(reshape(obj.modQ_cens, [], obj.ncuts), 1);
+            modQ_cens = zeros(1, obj.ncuts);
+            for icut = 1:obj.ncuts
+                modQ_cens(icut) = mean(obj.modQ_cens(obj.modQ_icuts == icut));
+            end
         end
 
         function cut = cut_2d_data(obj, qmin, qmax, ycalc)

--- a/swfiles/sw_fitpowder.m
+++ b/swfiles/sw_fitpowder.m
@@ -849,7 +849,7 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
             if numel(unique_counts) == 1 && unique_counts == obj.nQ
                 % avg successive nQ points along |Q| axis (dim=2)
                 ycalc_1d = reshape(ycalc, size(ycalc,1), obj.nQ, []);
-                ycalc_1d = squeeze(mean(ycalc, 2, 'omitnan'));
+                ycalc_1d = squeeze(mean(ycalc_1d, 2, 'omitnan'));
             else
                 % different num Q points per cut, loop over cuts
                 ycalc_1d = zeros(size(ycalc, 1), obj.ncuts);

--- a/swfiles/sw_fitpowder.m
+++ b/swfiles/sw_fitpowder.m
@@ -769,8 +769,9 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
                    'This function is only valid for 2D data');
             cut = struct('x', obj.ebin_cens, 'qmin',  qmin, 'qmax', qmax);
             ikeep = obj.modQ_cens > qmin & obj.modQ_cens <= qmax;
+            ifinite = isfinite(obj.y(:, ikeep));
             cut.y = mean(obj.y(:, ikeep), 2, 'omitnan');
-            cut.e = sqrt(sum(obj.e(:, ikeep).^2, 2))/sum(ikeep);
+            cut.e = sqrt(sum(obj.e(:, ikeep).^2, 2))./sum(ifinite, 2);
         end
         function ycalc = rebin_powspec_to_1D_cuts(obj, ycalc)
             % sum up successive nQ points along |Q| axis (dim=2)

--- a/swfiles/sw_fitpowder.m
+++ b/swfiles/sw_fitpowder.m
@@ -213,8 +213,8 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
             else
                 nparams_bg_total = obj.nparams_bg;
                 % add modQ polynopmial label
-                obj.bg_param_labels = [obj.bg_param_labels;
-                                       repmat("Q", obj.npoly_modQ, 1) + [obj.npoly_modQ:-1:1]'];
+                obj.bg_param_labels = [repmat("Q", obj.npoly_modQ, 1) + [obj.npoly_modQ:-1:1]';
+                                       obj.bg_param_labels;];
             end
             bg_params = zeros(nparams_bg_total, 1);
             bg_bounds = [-inf, inf].*ones(nparams_bg_total, 1);
@@ -701,7 +701,7 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
                 bg = mean(obj.y(obj.ibg));
             end
             % set constant background assuming last bg parameter
-            obj.set_bg_parameters(obj.nparams_bg, bg);  % set constant background
+            obj.set_bg_parameters("E0", bg);  % set constant background
         end
 
         function set_errors_of_bg_bins(obj, val)

--- a/swfiles/sw_fitpowder.m
+++ b/swfiles/sw_fitpowder.m
@@ -254,7 +254,7 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
 
         function set_background_strategy(obj, strategy)
             if strategy == "planar"
-                obj.fbg = @(en, modQ, p) obj.fbg_planar(en, modQ, p, obj.npoly_en);
+                obj.fbg = @(en, modQ, p) obj.fbg_planar(en, modQ, p, obj.npoly_modQ);
             elseif strategy == "independent"
                 if obj.ndim == 2
                     error('sw_fitpowder:invalidinput', ...
@@ -325,6 +325,9 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
         function set_bg_parameters(obj, iparams_bg, values, icuts)
             if nargin < 4
                 icuts = 0;
+            end
+            if  ischar(iparams_bg) || iscell(iparams_bg)  % Handles character arrays
+                iparams_bg = string(iparams_bg);
             end
             for ival = 1:numel(values)
                 iparams = obj.get_index_of_background_parameters(iparams_bg(ival), icuts);

--- a/swfiles/sw_fitpowder.m
+++ b/swfiles/sw_fitpowder.m
@@ -573,7 +573,11 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
             params = obj.params;
             params(end) = 1;
             [ycalc, bg] = calc_spinwave_spec(obj, params);
-            scale = max(obj.y - mean(bg(:)), [], "all")/max(ycalc, [], "all");
+            if obj.ndim == 1 && obj.background_strategy=="planar"
+                % integrate nQ |Q| points for each cut
+                bg = obj.rebin_powspec_to_1D_cuts(bg);
+            end
+            scale = max(obj.y - bg, [], "all")/max(ycalc - bg, [], "all");
             obj.params(end) = scale;
         end
 

--- a/swfiles/sw_fitpowder.m
+++ b/swfiles/sw_fitpowder.m
@@ -389,7 +389,8 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
                 obj.ndim = 1;
                 obj.ebin_cens = data(1).x;
                 obj.ncuts = numel(data);
-                for cut = data
+                for icut = 1:obj.ncuts
+                    cut = data(icut);
                     assert(all(isfield(cut, {'x', 'y', 'e', 'qmin','qmax'})), ...
                            'sw_fitpowder:invalidinput', ...
                            'Input cell does not have correct fields');
@@ -398,10 +399,10 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
                     dQ = (cut.qmax - cut.qmin)/obj.nQ;
                     if isfield(cut, 'qs')
                         obj.modQ_cens = [obj.modQ_cens, cut.qs(:)'];
-                        obj.modQ_icuts = [obj.modQ_icuts, ones(1, numel(cut.qs))];
+                        obj.modQ_icuts = [obj.modQ_icuts, icut*ones(1, numel(cut.qs))];
                     else
                         obj.modQ_cens = [obj.modQ_cens, ((cut.qmin+dQ/2):dQ:cut.qmax)];
-                        obj.modQ_icuts = [obj.modQ_icuts, ones(1, obj.nQ)];
+                        obj.modQ_icuts = [obj.modQ_icuts, icut*ones(1, obj.nQ)];
                     end
                 end
             end
@@ -824,7 +825,7 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
         end
         function ycalc_1d = rebin_powspec_to_1D_cuts(obj, ycalc)
             % check if regular nQ points for each cut
-            counts = groupcounts(obj.modQ_icuts);
+            counts = groupcounts(obj.modQ_icuts(:));
             unique_counts = unique(counts);
             if numel(unique_counts) == 1 && unique_counts == obj.nQ
                 % avg successive nQ points along |Q| axis (dim=2)
@@ -832,7 +833,7 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
                 ycalc_1d = squeeze(mean(ycalc, 2, 'omitnan'));
             else
                 % different num Q points per cut, loop over cuts
-                ycalc_1d = zeros(size(ycalc));
+                ycalc_1d = zeros(size(ycalc, 1), obj.ncuts);
                 for icut = 1:obj.ncuts
                     ikeep = obj.modQ_icuts == icut;
                     ycalc_1d(:, icut) = mean(ycalc(:, ikeep), 2, 'omitnan');

--- a/swfiles/sw_fitpowder.m
+++ b/swfiles/sw_fitpowder.m
@@ -230,8 +230,7 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
                 error('sw_fitpowder:invalidinput', ...
                       'Not enough 1D cuts to fit polynomial of order npoly_modQ.');
             end
-            % zero-init bg parmas and nparams_bg
-            obj.npoly_modQ = int32(npoly_modQ);
+            obj.npoly_modQ = round(npoly_modQ);
             obj.nparams_bg = obj.get_nparams_in_background_func();
             obj.initialise_background_parameters_and_bounds();
         end
@@ -241,7 +240,7 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
                 error('sw_fitpowder:invalidinput', ...
                       'npoly_en must be positive int');
             end
-            obj.npoly_en = int32(npoly_en);
+            obj.npoly_en = round(npoly_en);
             obj.nparams_bg = obj.get_nparams_in_background_func();
             obj.initialise_background_parameters_and_bounds();
         end

--- a/swfiles/sw_fitpowder.m
+++ b/swfiles/sw_fitpowder.m
@@ -361,6 +361,25 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
             obj.set_bounds(size(obj.bounds,1), lb, ub);
         end
 
+        function data = export_data(obj)
+            if obj.ndim == 2
+                data.y = obj.y';
+                data.e = obj.e';
+                data.x = {obj.ebin_cens, obj.modQ_cens};
+            else
+                % 1D - array of structs returned
+                data = repelem(struct('x', obj.ebin_cens), obj.ncuts);
+                for icut = 1:obj.ncuts
+                    data(icut).y = obj.y(:, icut);
+                    data(icut).e = obj.e(:, icut);
+                    % find q limits
+                    data(icut).qs = obj.modQ_cens(obj.modQ_icuts == icut);
+                    data(icut).qmin = data(icut).qs(1);
+                    data(icut).qmax = data(icut).qs(end);
+                end
+            end
+        end
+
         function add_data(obj, data)
             if ~isa(data, "struct")
                 data = arrayfun(@obj.convert_horace_to_struct, data);

--- a/swfiles/sw_fitpowder.m
+++ b/swfiles/sw_fitpowder.m
@@ -420,11 +420,11 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
                            'Input cell does not have correct fields');
                     obj.y = [obj.y cut.y(:)];
                     obj.e = [obj.e cut.e(:)];
-                    dQ = (cut.qmax - cut.qmin)/obj.nQ;
                     if isfield(cut, 'qs')
                         obj.modQ_cens = [obj.modQ_cens, cut.qs(:)'];
                         obj.modQ_icuts = [obj.modQ_icuts, icut*ones(1, numel(cut.qs))];
                     else
+                        dQ = (cut.qmax - cut.qmin)/obj.nQ;
                         obj.modQ_cens = [obj.modQ_cens, ((cut.qmin+dQ/2):dQ:cut.qmax)];
                         obj.modQ_icuts = [obj.modQ_icuts, icut*ones(1, obj.nQ)];
                     end

--- a/swfiles/sw_fitpowder.m
+++ b/swfiles/sw_fitpowder.m
@@ -430,8 +430,12 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
         function clear_cache(obj)
             obj.ycalc_cached = [];
             obj.model_params_cached = [];
+            obj.clear_background_region();
+        end
+
+        function clear_background_region(obj)
             obj.ibg = [];
-            obj.reset_errors_of_bg_bins()
+            obj.reset_errors_of_bg_bins();
         end
 
         function set_bg_region(obj, en_lo, en_hi, varargin)

--- a/swfiles/sw_fitpowder.m
+++ b/swfiles/sw_fitpowder.m
@@ -415,7 +415,9 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
                 obj.ncuts = numel(data);
                 for icut = 1:obj.ncuts
                     cut = data(icut);
-                    assert(all(isfield(cut, {'x', 'y', 'e', 'qmin','qmax'})), ...
+                    has_xye = all(isfield(cut, {'x', 'y', 'e'}));
+                    has_qfields = all(isfield(cut, {'qmin', 'qmax'})) || isfield(cut, 'qs');
+                    assert(has_xye && has_qfields, ...
                            'sw_fitpowder:invalidinput', ...
                            'Input cell does not have correct fields');
                     obj.y = [obj.y cut.y(:)];

--- a/swfiles/sw_fitpowder.m
+++ b/swfiles/sw_fitpowder.m
@@ -370,12 +370,12 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
                 % 1D - array of structs returned
                 data = repelem(struct('x', obj.ebin_cens), obj.ncuts);
                 for icut = 1:obj.ncuts
-                    data(icut).y = obj.y(:, icut);
-                    data(icut).e = obj.e(:, icut);
-                    % find q limits
-                    data(icut).qs = obj.modQ_cens(obj.modQ_icuts == icut);
-                    data(icut).qmin = data(icut).qs(1);
-                    data(icut).qmax = data(icut).qs(end);
+                    data(icut).y = obj.y(:, icut)';
+                    data(icut).e = obj.e(:, icut)';
+                    % find q limits (bin edges)
+                    qs = obj.modQ_cens(obj.modQ_icuts == icut);
+                    data(icut).qmin = qs(1) - 0.5*(qs(2)-qs(1));
+                    data(icut).qmax = qs(end) + 0.5*(qs(end)-qs(end-1));
                 end
             end
         end

--- a/swfiles/sw_fitpowder.m
+++ b/swfiles/sw_fitpowder.m
@@ -362,7 +362,7 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
             obj.set_bounds(size(obj.bounds,1), lb, ub);
         end
 
-        function data = export_data(obj)
+        function data = export_data(obj, filename)
             if obj.ndim == 2
                 data.y = obj.y';
                 data.e = obj.e';
@@ -378,6 +378,9 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
                     data(icut).qmin = qs(1) - 0.5*(qs(2)-qs(1));
                     data(icut).qmax = qs(end) + 0.5*(qs(end)-qs(end-1));
                 end
+            end
+            if nargin > 1
+                save(filename, 'data');
             end
         end
 

--- a/swfiles/sw_fitpowder.m
+++ b/swfiles/sw_fitpowder.m
@@ -229,25 +229,26 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
                 error('sw_fitpowder:invalidinput', ...
                       'set_bg_npoly_modQ only applies to planar background');
             end
-            if npoly_modQ < 0
-                error('sw_fitpowder:invalidinput', ...
-                      'npoly_modQ must be positive int');
+            if abs(mod(npoly_modQ, 1)) > eps || npoly_modQ < 0
+                   error('sw_fitpowder:invalidinput', ...
+                         'npoly_modQ must be a positive integer');
             end
             if obj.ndim==1 && npoly_modQ > obj.ncuts - 1
                 error('sw_fitpowder:invalidinput', ...
                       'Not enough 1D cuts to fit polynomial of order npoly_modQ.');
             end
-            obj.npoly_modQ = round(npoly_modQ);
+
+            obj.npoly_modQ = npoly_modQ;
             obj.nparams_bg = obj.get_nparams_in_background_func();
             obj.initialise_background_parameters_and_bounds();
         end
 
         function set_bg_npoly_en(obj, npoly_en)
-            if npoly_en < 0
-                error('sw_fitpowder:invalidinput', ...
-                      'npoly_en must be positive int');
+            if abs(mod(npoly_en, 1)) > eps || npoly_en < 0
+                   error('sw_fitpowder:invalidinput', ...
+                         'npoly_en must be a positive integer');
             end
-            obj.npoly_en = round(npoly_en);
+            obj.npoly_en = npoly_en;
             obj.nparams_bg = obj.get_nparams_in_background_func();
             obj.initialise_background_parameters_and_bounds();
         end

--- a/swfiles/sw_fitpowder.m
+++ b/swfiles/sw_fitpowder.m
@@ -549,7 +549,7 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
             varargout = {cov}; 
         end
 
-        function fit_background(obj, varargin)
+        function varargout = fit_background(obj, varargin)
             if isempty(obj.ibg)
                 obj.find_indices_and_mean_of_bg_bins();
             end
@@ -567,18 +567,13 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
             else
                 fobj = @obj.calc_cost_func_of_background; % minimise scalar
             end
-
-            [bg_params, ~, stat] = ndbase.simplex([], fobj, ...
-                                                  obj.params(ibg_par)', ...
-                                                 'lb', obj.bounds(ibg_par,1)', ...
-                                                 'ub', obj.bounds(ibg_par,2)', ...
-                                                  varargin{:});
-            if stat.exitFlag == 1
-                obj.params(ibg_par) = bg_params;
-            else
-                warning('spinw:sw_fitpowder:fit_background', ...
-                        'Fit failed - parameters not updated.');
-            end
+            varargout = cell(1,nargout(obj.optimizer));
+            [varargout{:}] = obj.optimizer([], fobj, ...
+                                           obj.params(ibg_par)', ...
+                                          'lb', obj.bounds(ibg_par,1)', ...
+                                          'ub', obj.bounds(ibg_par,2)', ...
+                                           varargin{:});
+            obj.params(ibg_par) = varargout{1}(:);
         end
 
         function estimate_scale_factor(obj)

--- a/swfiles/sw_fitpowder.m
+++ b/swfiles/sw_fitpowder.m
@@ -807,6 +807,60 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
             end
         end
 
+        function disp_params(obj,pfit, perr)
+            col_headers = ["Index", "Initial"];
+            pars = obj.params(:);
+            par_fmt = "%8g\t";
+            fmt_str = "%8.0f\t" + par_fmt;
+            if nargin > 1
+                assert(numel(pfit) == numel(obj.params), ...
+                       'sw_fitpowder:invalidinput', ...
+                       'Fit params vector has invlaid length.');
+                col_headers = [col_headers, "Best Fit"];
+                pars = [pars, pfit(:)];
+                fmt_str = fmt_str + par_fmt;
+            end
+            if nargin == 3
+                assert(numel(perr) == numel(obj.params), ...
+                       'sw_fitpowder:invalidinput', ...
+                       'Fit error vector has invlaid length.');
+                col_headers = [col_headers, "Error"];
+                pars = [pars, perr(:)];
+                fmt_str = fmt_str + par_fmt;
+            end
+            fmt_str = fmt_str + "\n";
+            % print model params
+            fprintf("---\nMODEL\n---\n")
+            fprintf([repmat('%s\t\t', 1,numel(col_headers)), '\n'], col_headers);
+            imodel = [1:obj.nparams_model]';
+            fprintf(fmt_str, [imodel, pars(imodel,:)]');
+            % print scale
+            scales = sprintf(par_fmt, pars(end,:));
+            fprintf("%8s\t%s\n", "SCALE", scales);
+            % print background
+            fprintf("---\nBACKGROUND\n---\n")
+            bg_pars = pars(obj.nparams_model+1:size(pars, 1)-1, :);
+            labels = obj.bg_param_labels;
+            col_headers = col_headers(2:end);  % excl. Index
+            bg_par_index = [1:obj.nparams_bg]';
+            if obj.ndim == 1 && obj.background_strategy == "independent"
+                % add icut column
+                col_headers = ["Cut Index", col_headers];
+                fmt_str = "%.0f\t" + fmt_str;
+                cut_index = repelem([1:obj.ncuts]', obj.nparams_bg,1);
+                bg_pars = [cut_index , bg_pars];
+                bg_par_index = repmat(bg_par_index, obj.ncuts, 1);
+                labels = repmat(labels, obj.ncuts, 1);
+            end
+            bg_pars = [bg_par_index, bg_pars];
+            col_headers = ["Label", "Index", col_headers];
+            fprintf([repmat('%s\t', 1,numel(col_headers)), '\n'], col_headers);
+            for irow = 1:size(bg_pars, 1)
+                row = sprintf(fmt_str, bg_pars(irow,:));
+                fprintf("%5s\t%s", labels(irow), row);
+            end
+        end
+
     end
 
     % private

--- a/swfiles/sw_fitpowder.m
+++ b/swfiles/sw_fitpowder.m
@@ -754,7 +754,7 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
             ax = gca;
             box on; hold on;
             h = imagesc(ax, obj.modQ_cens, obj.ebin_cens, y);
-            h.AlphaData = double(obj.y > 0);  % make empty bins transparent
+            h.AlphaData = double(obj.e > 0);  % make empty bins transparent
             cbar = colorbar(ax);
             cbar.Label.String = "Intensity";
             xlabel(ax, "$\left|Q\right| (\AA^{-1})$", 'interpreter','latex');
@@ -791,11 +791,11 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
                 hold on; box on;
                 if ~isempty(ycalc)
                     cut = obj.cut_2d_data(qmins(icut), qmaxs(icut), ycalc);
-                    plot(ax, cut.x, cut.ycalc, '-r');
+                    plot(ax, cut.x, cut.ycalc, '-r', 'DisplayName', 'Fit');
                 else
                     cut = obj.cut_2d_data(qmins(icut), qmaxs(icut));
                 end
-                plot(ax, cut.x, cut.y, 'ok');
+                plot(ax, cut.x, cut.y, 'ok', 'DisplayName', 'Data');
                 % calc xlims
                 ifinite = isfinite(cut.y);
                 istart = find(ifinite, 1, 'first');

--- a/swfiles/sw_fitpowder.m
+++ b/swfiles/sw_fitpowder.m
@@ -504,6 +504,19 @@ classdef sw_fitpowder < handle & matlab.mixin.SetGet
                                        varargin{:});
         end
 
+        function varargout = fit_background_and_scale(obj, varargin) 
+            % fix all model parameters
+            initial_bounds = obj.bounds; % store so bounds can be reset
+            obj.fix_model_parameters(1:obj.nparams_model);
+            varargout = cell(1,nargout(obj.optimizer));
+            [varargout{:}] = obj.fit(varargin{:});
+            % reset bounds
+            obj.bounds = initial_bounds;
+            % overwrite non model parameters
+            obj.params = varargout{1}(:); % assume first output (as for ndbase)
+        end
+
+
         function [param_errors, varargout] = calc_uncertainty(obj, params, varargin)
         % Function to estimate parameter errors by evaluating hessian.
         % By default will only evaluate derivatives for parameters

--- a/tutorials/publish/tutorial39.m
+++ b/tutorials/publish/tutorial39.m
@@ -78,7 +78,7 @@ fitpow.set_caching(true); % will store last calculated spectra
 fitpow.powspec_args.dE = eres; % emergy resolution
 fitpow.powspec_args.fastmode = true;
 fitpow.powspec_args.neutron_output = true;
-fitpow.powspec_args.nRand = 1e3; % low for speed (typically want > 1e3)
+fitpow.powspec_args.nRand = 1e3;
 fitpow.powspec_args.hermit = true;
 % set parameters passsed to sw_instrument
 fitpow.sw_instrument_args = struct('dQ', dQ, 'ThetaMin', 3.5, 'Ei', Ei);


### PR DESCRIPTION
**Description**

Various bugs and small features:
- Fix bug in scale factor estimation
- Add new function to fit bg and scale to all data  (fixing model)
- Support any ndbase optimizer in fit_background
- Add methods to set and clear background region
- Add method to plot background region
- Initialise background parameters with sensible values when switching background  strategy 
- Handle edges/nans properly in avg. of error when taking 1D cuts
- Support general polynomial background in Q and en
- Use 2D data Q bins when replace with 1D cuts (previously just used nQ bins between qmin and qmax)
- Update tutorial
- Add method to export data into structs (or array of structs for 1D) - for fitbenchmarking
- Add ability to set background parameters, bounds etc. by string label
- Add method to print parameters nicely

**To Test**
(1) Run tutorial 39 file