### PR TITLE
Fix out-of-bounds bug in mex code

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -30,6 +30,12 @@ jobs:
         uses: matlab-actions/setup-matlab@v2
         with:
           release: ${{ matrix.matlab_version }}
+      - name: Set GCC version on Linux
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          sudo apt install -y gcc-12 g++-12
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 10
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 10
       - name: Run tests
         uses: matlab-actions/run-command@v2
         with:

--- a/external/chol_omp/chol_omp.cpp
+++ b/external/chol_omp/chol_omp.cpp
@@ -214,12 +214,15 @@ int do_loop(mxArray *plhs[], const mxArray *prhs[], int nthread, mwSignedIndex m
             int *blkid, char uplo, T tol, bool do_Colpa)
 {
     int err_nonpos = 0, err_singular = 0;
-    T* lhs0 = (T*)mxGetData(plhs[0]);
-    T* lhs1 = (T*)mxGetData(plhs[1]);
+    T *lhs0, *ilhs0, *lhs1, *ilhs1;
+    lhs0 = (T*)mxGetData(plhs[0]);
+    ilhs0 = (T*)mxGetImagData(plhs[0]);
+    if (nlhs > 1) {
+        lhs1 = (T*)mxGetData(plhs[1]);
+        ilhs1 = (T*)mxGetImagData(plhs[1]);
+    }
     T* rhs0 = (T*)mxGetData(prhs[0]);
     T* irhs0 = (T*)mxGetImagData(prhs[0]);
-    T* ilhs0 = (T*)mxGetImagData(plhs[0]);
-    T* ilhs1 = (T*)mxGetImagData(plhs[1]);
     bool is_complex = mxIsComplex(prhs[0]);
 #pragma omp parallel default(none) shared(err_nonpos, err_singular) \
     firstprivate(nthread, m, nlhs, blkid, uplo, tol, do_Colpa, lhs0, lhs1, rhs0, irhs0, ilhs0, ilhs1, is_complex)

--- a/external/eig_omp/eig_omp.cpp
+++ b/external/eig_omp/eig_omp.cpp
@@ -681,10 +681,13 @@ int do_loop(T *mat, T *mat_i, mxArray *plhs[], int nthread, mwSignedIndex m, int
     const int *blkid, char jobz, bool anynonsym, const bool *issym, bool do_orth, int do_sort, bool is_complex)
 {
     int err_code = 0;
-    T* lhs0 = (T*)mxGetData(plhs[0]);
-    T* lhs1 = (T*)mxGetData(plhs[1]);
-    T* ilhs0 = (T*)mxGetImagData(plhs[0]);
-    T* ilhs1 = (T*)mxGetImagData(plhs[1]);
+    T *lhs0, *ilhs0, *lhs1, *ilhs1;
+    lhs0 = (T*)mxGetData(plhs[0]);
+    ilhs0 = (T*)mxGetImagData(plhs[0]);
+    if (nlhs > 1) {
+        lhs1 = (T*)mxGetData(plhs[1]);
+        ilhs1 = (T*)mxGetImagData(plhs[1]);
+    }
 #pragma omp parallel default(none) shared(mat, mat_i, err_code, blkid, issym) \
     firstprivate(nthread, m, nlhs, nd, jobz, anynonsym, do_orth, do_sort, is_complex, lhs0, lhs1, ilhs0, ilhs1)
     {


### PR DESCRIPTION
There was an ancient bug in the parallelised `eig` and `chol` code which failed to check the number of output variables `nlhs` and tries to access a pointer which does not exist.

In older versions of Matlab this seems to work (the routines get a pointer to the actual data using `mxGetData` given the address of an `mxArray` but never uses that pointer), but with Matlab 2023a and newer this causes a segmentation fault because the internal behaviour of `mxGetData` / the internal definition of the opaque `mxArray` class/struct has changed.

Specifically, the code tries to access the output pointers array `plhs[]` which has `nlhs` elements long but the code always assumes that `nlhs` is at lease `2`. Hence when `nlhs=1`, `plhs[1]` is a junk pointer. I suspect that in older versions of Matlab, `mxGetData` just returns the input pointer plus an offset, which will work with a junk input pointer as long as no processing is done on the (junk) output. I think that in newer versions of Matlab, `mxGetData` actually tries to dereference the `mxArray` structure to access its `pr` member (the data pointer), and this will give a segfault because the input pointer is junk.

The PR now checks what `nlhs` is and guards against this out-of-bounds error.