### PR TITLE
Fix bugs identified by user

### DIFF
--- a/swfiles/sw_plotspec.m
+++ b/swfiles/sw_plotspec.m
@@ -812,7 +812,10 @@ if param.mode == 3
         iName = strsplit(strtrim(sprintf('I%d ',1:nMode)),' ');
         eName = strsplit(strtrim(sprintf('EN%d ',1:nMode)),' ');
         sName = strsplit(strtrim(sprintf('s%d ',1:nMode)),' ');
-        
+        if ~isfield(T, sName)
+           sName = strsplit(strtrim(sprintf('sigma%d ',1:nMode)),' ');
+        end
+
         dat.I = zeros(nMode,nQ);
         dat.E = zeros(nMode,nQ);
         dat.s = zeros(nMode,nQ);

--- a/tutorials/publish/tutorial12.m
+++ b/tutorials/publish/tutorial12.m
@@ -78,7 +78,7 @@ if ~exist('sqw','file')
 end
 
 horaceObj = d3d(tri.abc,[1 0 0 0],[0,0.005,1],[0 1 0 0],[0,0.005,1],[0 0 0 1],[0,0.1,10]);
-horaceObj = disp2sqw_eval(horaceObj,@tri.horace,{'component','Sperp'},dE);
+horaceObj = disp2sqw_eval(horaceObj,@tri.horace,{'component','Sperp'},dE,'-all');
 cut1 = cut(horaceObj,[],[],[3.0 3.5]);
 
 % We use the honest colormap cm_inferno.

--- a/tutorials/publish/tutorial12/tutorial12.html
+++ b/tutorials/publish/tutorial12/tutorial12.html
@@ -103,7 +103,7 @@ dE = 0.15;
 <span class="comment">% Horace function.</span>
 
 horaceObj = d3d(tri.abc,[1 0 0 0],[0,0.005,1],[0 1 0 0],[0,0.005,1],[0 0 0 1],[0,0.1,10]);
-horaceObj = disp2sqw_eval(horaceObj,@tri.horace,{<span class="string">'component'</span>,<span class="string">'Sperp'</span>},dE);
+horaceObj = disp2sqw_eval(horaceObj,@tri.horace,{<span class="string">'component'</span>,<span class="string">'Sperp'</span>},dE,'-all');
 cut1 = cut(horaceObj,[],[],[3.0 3.5]);
 
 <span class="comment">% We use the honest colormap cm_inferno.</span>
@@ -192,7 +192,7 @@ dE = 0.15;
 % Horace function.
 
 horaceObj = d3d(tri.abc,[1 0 0 0],[0,0.005,1],[0 1 0 0],[0,0.005,1],[0 0 0 1],[0,0.1,10]);
-horaceObj = disp2sqw_eval(horaceObj,@tri.horace,{'component','Sperp'},dE);
+horaceObj = disp2sqw_eval(horaceObj,@tri.horace,{'component','Sperp'},dE,'-all');
 cut1 = cut(horaceObj,[],[],[3.0 3.5]);
 
 % We use the honest colormap cm_inferno.

--- a/tutorials/publish/tutorial12/tutorial12.txt
+++ b/tutorials/publish/tutorial12/tutorial12.txt
@@ -35,7 +35,7 @@ dE = 0.15;
 <span class="comment">% Horace function.</span>
 
 horaceObj = d3d(tri.abc,[1 0 0 0],[0,0.005,1],[0 1 0 0],[0,0.005,1],[0 0 0 1],[0,0.1,10]);
-horaceObj = disp2sqw_eval(horaceObj,@tri.horace,{<span class="string">'component'</span>,<span class="string">'Sperp'</span>},dE);
+horaceObj = disp2sqw_eval(horaceObj,@tri.horace,{<span class="string">'component'</span>,<span class="string">'Sperp'</span>},dE,'-all');
 cut1 = cut(horaceObj,[],[],[3.0 3.5]);
 
 <span class="comment">% We use the honest colormap cm_inferno.</span>
@@ -124,7 +124,7 @@ dE = 0.15;
 % Horace function.
 
 horaceObj = d3d(tri.abc,[1 0 0 0],[0,0.005,1],[0 1 0 0],[0,0.005,1],[0 0 0 1],[0,0.1,10]);
-horaceObj = disp2sqw_eval(horaceObj,@tri.horace,{'component','Sperp'},dE);
+horaceObj = disp2sqw_eval(horaceObj,@tri.horace,{'component','Sperp'},dE,'-all');
 cut1 = cut(horaceObj,[],[],[3.0 3.5]);
 
 % We use the honest colormap cm_inferno.


### PR DESCRIPTION
C. Balz contacted me with some bugs - specifically relating to tutorials 12 and 35:

* The syntax for `disp2sqw_eval` in Horace has changed and needs a flag `'-all'` at the end to compute the intensities, so we need to change the example in tutorial 12.
* ~~In tutorial 35, a long-known bug is that the experiment points shift if you resize the figure because they are actually `'circles'` plotted on the canvas coordinates rather than the data coordinates. There are two work arounds which should be documented.~~ - [Fixed](https://github.com/SpinW/spinw.github.io/commit/13f79945e6575755dd63e3c8cb56c04c520276bf) on webpage already
* Finally, also related to tutorial 35 but not in the tutorial itself - `sw_plotspec` has the option to overplot data (like `fitspec` does) but it assumes that the column names are `En#`, `I#`, and `s#` whereas `fitspec` ignores the names and just uses the column ordering - but the example file [LuVO3_fitted_modes.txt](https://raw.githubusercontent.com/SpinW/spinw/master/tutorials/publish/LuVO3_fitted_modes.txt) calls the final column `sigma#` rather than `s#` so `sw_plotspec` fails when given it as input.